### PR TITLE
Add missing rule for marking DUL-captured usage with namespace DUL

### DIFF
--- a/source/06-logging/03-distributed-usage-logging.rst
+++ b/source/06-logging/03-distributed-usage-logging.rst
@@ -11,7 +11,8 @@ Distributed Usage Logging (DUL) is an initiative sponsored by Crossref (see `DUL
 * DUL is not a replacement for log file analysis or page-tagging approaches. DUL can supplement a publisher’s normal usage logging mechanisms, but not replace them.
 * DUL-captured usage MUST NOT appear on Standard Views.
 * DUL-captured usage may appear on Master Reports.
-* DUL-captured usage captured that appears on Master Reports MUST be reported under the platform name where the transaction occurred.
+* DUL-captured usage that appears on Master Reports MUST be reported under the platform name where the transaction occurred.
+* The platform name MUST include the namespace DUL (i.e. MUST be in the format of DUL:*{platform name}*), so that DUL-captured usage can be identified and excluded when creating a Standard View from a Master Report.
 * An organization that supplies usage transactions using DUL MUST include their platform ID with each transaction, and their platform MUST be registered with COUNTER.
 * Reporting usage through DUL is OPTIONAL.
 * The publisher receiving transactions through DUL is responsible for performing COUNTER processing to eliminate double-clicks, eliminate robot/crawler or other rogue usage, and perform the actions to identify unique items and unique titles.


### PR DESCRIPTION
This pull request resolves #63.