### PR TITLE
Clarify rules for using byte order marks in reports in text formats

### DIFF
--- a/source/05-delivery/index.rst
+++ b/source/05-delivery/index.rst
@@ -14,7 +14,7 @@ Content providers MUST make tabular versions of COUNTER reports available from a
   * In tabular form as either an Excel or a tab-separated-value (TSV) file, or both. Additional file formats that can be easily imported into spreadsheet programs without loss or corruption may be offered at the vendor's discretion.
   * JSON formatted in accordance with the COUNTER_SUSHI API Specification (see :numref:`sushi` below).
 
-* The reports in JSON, TSV and other text formats MUST be encoded using UTF-8.
+* The reports in JSON, TSV and other text formats MUST be encoded using UTF-8. Tabular reports in text formats SHOULD include a byte order mark, so that spreadsheet programs can automatically detect the encoding. JSON reports and other SUSHI server responses MUST NOT include a byte order mark (according to `RFC 8259, Section 8.1 <https://datatracker.ietf.org/doc/html/rfc8259#section-8.1>`_).
 * Each report MUST be delivered as a separate file to facilitate automated processing of usage reports into ERM and usage consolidation systems. For clarity, multiple reports MUST NOT be included in the same Excel file as separate worksheets.
 * Tabular reports MUST be made available through a website.
 


### PR DESCRIPTION
This pull request resolves #65.