### PR TITLE
Restore README for SwaggerHub integration

### DIFF
--- a/sushi-api/README.rst
+++ b/sushi-api/README.rst
@@ -1,0 +1,8 @@
+COUNTER_SUSHI API Specification
+===============================
+
+The COUNTER_SUSHI API Specification is maintained by COUNTER on SwaggerHub:
+
+  https://app.swaggerhub.com/apis/COUNTER/counter-sushi_5_0_api/
+
+Starting with the publication of Release 5.0.2 the SwaggerHub feature "GitHub Sync" is used to also track changes to the COUNTER_SUSHI API Specification in this repository. The version of the Swagger file for the COUNTER_SUSHI API included in this directory (in unresolved JSON format) corresponds to the repository branch.


### PR DESCRIPTION
This pull request restores the README that was accidentally deleted by the SwaggerHub GitHub Sync, it resolves #107.