### PR TITLE
Remove IP address authorization from COUNTER_SUSHI API

### DIFF
--- a/source/08-sushi/02-authentication-and-security-for-counter-sushi-api.rst
+++ b/source/08-sushi/02-authentication-and-security-for-counter-sushi-api.rst
@@ -2,19 +2,18 @@
    is licensed under CC BY-SA 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by-sa/4.0/
 
-Authentication and Security for COUNTER_SUSHI API
--------------------------------------------------
+Authentication and Security for the COUNTER_SUSHI API
+-----------------------------------------------------
 
 The COUNTER_SUSHI API MUST be implemented using TLS (HTTPS).
 
 The API MUST be secured using one or more of the following methods:
 
 * Combination of customer ID and requestor ID
-* IP address of the SUSHI client
 * API key assigned to the organization harvesting the usage
 
-Non-standard techniques for authentication (techniques not specified in the COUNTER_SUSHI API specification) MUST NOT be used.
+Non-standard techniques (not specified in the Code of Practice and the COUNTER_SUSHI API specification) MUST NOT be used. This includes authorization based on IP addresses.
 
-If IP address authentication is implemented, it MUST allow the same SUSHI client (a single IP address) to harvest usage for multiple customer accounts (e.g. hosted ERM services).
+Report providers who would like to improve the security of their SUSHI server should consider using API keys with secure values (e.g. randomly generated UUIDs). Report providers who already use requestor IDs and/or customer IDs with secure values should consider that adding an API key would require all report consumers to update their SUSHI credentials.
 
 If global reports are available, the customer ID 0000000000000000 should be used for "The World". The report should be available to any valid requestor ID and/or API key.

--- a/source/appendices/d-handling-errors-and-exceptions.rst
+++ b/source/appendices/d-handling-errors-and-exceptions.rst
@@ -138,11 +138,6 @@ Table D.1 (below): Exceptions
      - 401
      - The service requires a valid APIKey to access usage data and the key provided was not valid or not authorized for the data being requested.
 
-   * - IP Address Not Authorized to Access Service
-     - 2030
-     - 401
-     - The service requires IP authorization, and the IP address used by the client is not authorized. The server MUST include information on how this issue can be resolved in the Data element or include a Help_URL that points to the information.
-
    * - Invalid Date Arguments
      - 3020
      - 400


### PR DESCRIPTION
Remove IP address authorization from COUNTER_SUSHI API. Add recommendation to use API keys with secure values for improving the security of SUSHI servers.

This pull request resolves #206.