### PR TITLE
Update configuration for building the CoP documents

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,15 @@
-# .readthedocs.yml
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 # Build documentation in the source directory with Sphinx
 sphinx:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: sphinx
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 venv:
-	python3 -m venv venv
+	python3.11 -m venv venv
 	venv/bin/pip -q install --upgrade pip
 	venv/bin/pip -q install -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==5.3.0
+Sphinx==7.2.*
 sphinx-rtd-theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -35,7 +35,7 @@ release = '5.1'
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-needs_sphinx = '5.3.0'
+needs_sphinx = '7.2.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom


### PR DESCRIPTION
After some changes to ReadTheDocs the OS and Python version for building the Code of Practice documents now have to be specified, and the Python and Sphinx version have to be updated.