### PR TITLE
Remove Format extension from COUNTER API specification

### DIFF
--- a/sushi-api/COUNTER_SUSHI_API.json
+++ b/sushi-api/COUNTER_SUSHI_API.json
@@ -6569,7 +6569,6 @@
                                         "Subdivision_Name",
                                         "Subdivision_Code",
                                         "Attributed",
-                                        "Format",
                                         "Book_Segment_Count"
                                     ]
                                 }


### PR DESCRIPTION
Remove the Format extension, that was removed from the Code of Practice in R5.1, from the COUNTER API specification to bring it in line with the Code of Practice.