### PR TITLE
Add more examples to the COUNTER API Specification

### DIFF
--- a/api-specification/COUNTER_API.json
+++ b/api-specification/COUNTER_API.json
@@ -1311,13 +1311,154 @@
                     "Institution_Name",
                     "Customer_ID"
                 ],
+                "examples": [
+                    {
+                        "Customer_ID": "C12345",
+                        "Institution_Name": "Sample Institution",
+                        "Notes": "This is a sample customer",
+                        "Institution_ID": {
+                            "ISNI": [
+                                "1234123412341234"
+                            ]
+                        }
+                    }
+                ],
                 "x-tags": [
                     "Member List"
                 ]
             },
             "Report": {
                 "type": "object",
-                "examples": [],
+                "examples": [
+                    {
+                        "Report_Name": "Platform Report",
+                        "Report_ID": "PR",
+                        "Release": "5.1",
+                        "Report_Description": "A customizable report summarizing activity across a report provider’s platforms that allows the user to apply filters and select other configuration options.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Platform Usage",
+                        "Report_ID": "PR_P1",
+                        "Release": "5.1",
+                        "Report_Description": "Platform-level usage summarized by Metric_Type.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Database Report",
+                        "Report_ID": "DR",
+                        "Release": "5.1",
+                        "Report_Description": "A customizable report detailing activity by database that allows the user to apply filters and select other configuration options.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Database Search and Item Usage",
+                        "Report_ID": "DR_D1",
+                        "Release": "5.1",
+                        "Report_Description": "Reports on key Searches, Investigations and Requests metrics needed to evaluate a database.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Database Access Denied",
+                        "Report_ID": "DR_D2",
+                        "Release": "5.1",
+                        "Report_Description": "Reports on Access Denied activity for databases where users were denied access because simultaneous-use licenses were exceeded or their institution did not have a license for the database.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Title Report",
+                        "Report_ID": "TR",
+                        "Release": "5.1",
+                        "Report_Description": "A customizable report detailing activity at the title level (journal, book, etc.) that allows the user to apply filters and select other configuration options.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Book Requests (Controlled)",
+                        "Report_ID": "TR_B1",
+                        "Release": "5.1",
+                        "Report_Description": "Reports on full-text activity for books, excluding Open and Free_To_Read content, as Total_Item_Requests and Unique_Title_Requests.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Book Access Denied",
+                        "Report_ID": "TR_B2",
+                        "Release": "5.1",
+                        "Report_Description": "Reports on Access Denied activity for books where users were denied access because simultaneous-use licenses were exceeded or their institution did not have a license for the book.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Book Usage by Access Type",
+                        "Report_ID": "TR_B3",
+                        "Release": "5.1",
+                        "Report_Description": "Reports on book usage showing all applicable Metric_Types broken down by Access_Type.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Journal Requests (Controlled)",
+                        "Report_ID": "TR_J1",
+                        "Release": "5.1",
+                        "Report_Description": "Reports on usage of journal content, excluding Open and Free_To_Read content, as Total_Item_Requests and Unique_Item_Requests.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Journal Access Denied",
+                        "Report_ID": "TR_J2",
+                        "Release": "5.1",
+                        "Report_Description": "Reports on Access Denied activity for journal content where users were denied access because simultaneous-use licenses were exceeded or their institution did not have a license for the title.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Journal Usage by Access Type",
+                        "Report_ID": "TR_J3",
+                        "Release": "5.1",
+                        "Report_Description": "Reports on usage of journal content for all Metric_Types broken down by Access_Type.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Journal Requests by YOP (Controlled)",
+                        "Report_ID": "TR_J4",
+                        "Release": "5.1",
+                        "Report_Description": "Breaks down the usage of journal content, excluding Open and Free_To_Read content, by year of publication (YOP), providing counts for the Metric_Types Total_Item_Requests and Unique_Item_Requests.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Item Report",
+                        "Report_ID": "IR",
+                        "Release": "5.1",
+                        "Report_Description": "A granular, customizable report showing activity at the level of the item (article, chapter, media object, etc.) that allows the user to apply filters and select other configuration options.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Journal Article Requests",
+                        "Report_ID": "IR_A1",
+                        "Release": "5.1",
+                        "Report_Description": "Reports on journal article requests at the article level. This report is limited to content with a Data_Type of Article and Metric_Types of Total_Item_Requests and Unique_Item_Requests.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    },
+                    {
+                        "Report_Name": "Multimedia Item Requests",
+                        "Report_ID": "IR_M1",
+                        "Release": "5.1",
+                        "Report_Description": "Reports on multimedia requests at the item level.",
+                        "First_Month_Available": "2024-01",
+                        "Last_Month_Available": "2024-11"
+                    }
+                ],
                 "title": "Report Information",
                 "description": "Information about a report supported by a COUNTER API server.",
                 "x-stoplight": {
@@ -7115,6 +7256,31 @@
                 },
                 "type": "object",
                 "title": "Base Report_Header",
+                "examples": [
+                    {
+                        "Release": "5.1",
+                        "Report_ID": "PR",
+                        "Report_Name": "Platform Report",
+                        "Created": "2023-02-15T09:11:12Z",
+                        "Created_By": "Sample Publisher",
+                        "Institution_ID": {
+                            "ISNI": [
+                                "1234123412341234"
+                            ]
+                        },
+                        "Institution_Name": "Sample Institution",
+                        "Registry_Record": "https://registry.countermetrics.org/platform/99999999-9999-9999-9999-999999999999",
+                        "Report_Attributes": {
+                            "Attributes_To_Show": [
+                                "Access_Method"
+                            ]
+                        },
+                        "Report_Filters": {
+                            "Begin_Date": "2022-01-01",
+                            "End_Date": "2022-03-31"
+                        }
+                    }
+                ],
                 "x-tags": [
                     "Shared Models"
                 ],
@@ -7383,6 +7549,12 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "PR - Report_Filters",
+                "examples": [
+                    {
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31"
+                    }
+                ],
                 "x-tags": [
                     "PR - Platform Report"
                 ],
@@ -7422,6 +7594,13 @@
                 "minProperties": 1,
                 "unevaluatedProperties": false,
                 "title": "PR - Report_Attributes",
+                "examples": [
+                    {
+                        "Attributes_To_Show": [
+                            "Access_Method"
+                        ]
+                    }
+                ],
                 "x-tags": [
                     "PR - Platform Report"
                 ],
@@ -8158,6 +8337,19 @@
                     "PR - Platform Report"
                 ],
                 "title": "PR - Attribute_Performance Platform",
+                "examples": [
+                    {
+                        "Data_Type": "Platform",
+                        "Access_Method": "Regular",
+                        "Performance": {
+                            "Searches_Platform": {
+                                "2022-01": 17484,
+                                "2022-02": 18061,
+                                "2022-03": 17160
+                            }
+                        }
+                    }
+                ],
                 "x-stoplight": {
                     "id": "6s3l2a9vz6n3q"
                 }
@@ -8217,12 +8409,59 @@
                     "PR - Platform Report"
                 ],
                 "title": "PR - Attribute_Performance Other",
+                "examples": [
+                    {
+                        "Data_Type": "Book",
+                        "Access_Method": "Regular",
+                        "Performance": {
+                            "Total_Item_Investigations": {
+                                "2022-01": 1104,
+                                "2022-02": 1246,
+                                "2022-03": 1329
+                            },
+                            "Total_Item_Requests": {
+                                "2022-01": 662,
+                                "2022-02": 748,
+                                "2022-03": 797
+                            },
+                            "Unique_Item_Investigations": {
+                                "2022-01": 828,
+                                "2022-02": 935,
+                                "2022-03": 997
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 497,
+                                "2022-02": 561,
+                                "2022-03": 598
+                            },
+                            "Unique_Title_Investigations": {
+                                "2022-01": 552,
+                                "2022-02": 623,
+                                "2022-03": 665
+                            },
+                            "Unique_Title_Requests": {
+                                "2022-01": 414,
+                                "2022-02": 467,
+                                "2022-03": 499
+                            }
+                        }
+                    }
+                ],
                 "x-stoplight": {
                     "id": "dhem0q50ngzyd"
                 }
             },
             "PR_Performance_Platform": {
                 "title": "PR - Performance Platform",
+                "examples": [
+                    {
+                        "Searches_Platform": {
+                            "2022-01": 17484,
+                            "2022-02": 18061,
+                            "2022-03": 17160
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Searches_Platform": {
@@ -8240,6 +8479,40 @@
             },
             "PR_Performance_Other": {
                 "title": "PR - Performance Other",
+                "examples": [
+                    {
+                        "Total_Item_Investigations": {
+                            "2022-01": 1104,
+                            "2022-02": 1246,
+                            "2022-03": 1329
+                        },
+                        "Total_Item_Requests": {
+                            "2022-01": 662,
+                            "2022-02": 748,
+                            "2022-03": 797
+                        },
+                        "Unique_Item_Investigations": {
+                            "2022-01": 828,
+                            "2022-02": 935,
+                            "2022-03": 997
+                        },
+                        "Unique_Item_Requests": {
+                            "2022-01": 497,
+                            "2022-02": 561,
+                            "2022-03": 598
+                        },
+                        "Unique_Title_Investigations": {
+                            "2022-01": 552,
+                            "2022-02": 623,
+                            "2022-03": 665
+                        },
+                        "Unique_Title_Requests": {
+                            "2022-01": 414,
+                            "2022-02": 467,
+                            "2022-03": 499
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Total_Item_Investigations": {
@@ -8801,6 +9074,18 @@
             },
             "PR_P1_Attribute_Performance_Platform": {
                 "title": "PR_P1 - Attribute_Performance Platform",
+                "examples": [
+                    {
+                        "Data_Type": "Platform",
+                        "Performance": {
+                            "Searches_Platform": {
+                                "2022-01": 17484,
+                                "2022-02": 18061,
+                                "2022-03": 17160
+                            }
+                        }
+                    }
+                ],
                 "x-stoplight": {
                     "id": "vrr38jf3ovkga"
                 },
@@ -8825,6 +9110,28 @@
             },
             "PR_P1_Attribute_Performance_Other": {
                 "title": "PR_P1 - Attribute_Performance Other",
+                "examples": [
+                    {
+                        "Data_Type": "Book",
+                        "Performance": {
+                            "Total_Item_Requests": {
+                                "2022-01": 662,
+                                "2022-02": 748,
+                                "2022-03": 797
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 497,
+                                "2022-02": 561,
+                                "2022-03": 598
+                            },
+                            "Unique_Title_Requests": {
+                                "2022-01": 414,
+                                "2022-02": 467,
+                                "2022-03": 499
+                            }
+                        }
+                    }
+                ],
                 "x-stoplight": {
                     "id": "ywl8b81ap62xq"
                 },
@@ -8874,6 +9181,15 @@
             },
             "PR_P1_Performance_Platform": {
                 "title": "PR_P1 - Performance Platform",
+                "examples": [
+                    {
+                        "Searches_Platform": {
+                            "2022-01": 17484,
+                            "2022-02": 18061,
+                            "2022-03": 17160
+                        }
+                    }
+                ],
                 "x-stoplight": {
                     "id": "os1htj6tx0m5b"
                 },
@@ -8891,6 +9207,25 @@
             },
             "PR_P1_Performance_Other": {
                 "title": "PR_P1 - Performance Other",
+                "examples": [
+                    {
+                        "Total_Item_Requests": {
+                            "2022-01": 662,
+                            "2022-02": 748,
+                            "2022-03": 797
+                        },
+                        "Unique_Item_Requests": {
+                            "2022-01": 497,
+                            "2022-02": 561,
+                            "2022-03": 598
+                        },
+                        "Unique_Title_Requests": {
+                            "2022-01": 414,
+                            "2022-02": 467,
+                            "2022-03": 499
+                        }
+                    }
+                ],
                 "x-stoplight": {
                     "id": "mgu8ibcbgrwe0"
                 },
@@ -9045,6 +9380,12 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "DR - Report_Filters",
+                "examples": [
+                    {
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31"
+                    }
+                ],
                 "x-stoplight": {
                     "id": "arp83wbvfetzv"
                 },
@@ -9084,6 +9425,13 @@
                 "minProperties": 1,
                 "unevaluatedProperties": false,
                 "title": "DR - Report_Attributes",
+                "examples": [
+                    {
+                        "Attributes_To_Show": [
+                            "Access_Method"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "spnsr15bib3zr"
                 },
@@ -9542,6 +9890,39 @@
                     "DR - Database Report"
                 ],
                 "title": "DR - Attribute_Performance Database",
+                "examples": [
+                    {
+                        "Data_Type": "Database_Aggregated",
+                        "Access_Method": "Regular",
+                        "Performance": {
+                            "Limit_Exceeded": {
+                                "2022-01": 47,
+                                "2022-02": 59,
+                                "2022-03": 38
+                            },
+                            "No_License": {
+                                "2022-01": 41,
+                                "2022-02": 77,
+                                "2022-03": 42
+                            },
+                            "Searches_Automated": {
+                                "2022-01": 15888,
+                                "2022-02": 14802,
+                                "2022-03": 15488
+                            },
+                            "Searches_Federated": {
+                                "2022-01": 17178,
+                                "2022-02": 17517,
+                                "2022-03": 18637
+                            },
+                            "Searches_Regular": {
+                                "2022-01": 13878,
+                                "2022-02": 13332,
+                                "2022-03": 19412
+                            }
+                        }
+                    }
+                ],
                 "x-stoplight": {
                     "id": "7ii07dnc5weov"
                 }
@@ -9594,12 +9975,79 @@
                     "DR - Database Report"
                 ],
                 "title": "DR - Attribute_Performance Other",
+                "examples": [
+                    {
+                        "Data_Type": "Book",
+                        "Access_Method": "Regular",
+                        "Performance": {
+                            "Total_Item_Investigations": {
+                                "2022-01": 1104,
+                                "2022-02": 1246,
+                                "2022-03": 1329
+                            },
+                            "Total_Item_Requests": {
+                                "2022-01": 662,
+                                "2022-02": 748,
+                                "2022-03": 797
+                            },
+                            "Unique_Item_Investigations": {
+                                "2022-01": 828,
+                                "2022-02": 935,
+                                "2022-03": 997
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 497,
+                                "2022-02": 561,
+                                "2022-03": 598
+                            },
+                            "Unique_Title_Investigations": {
+                                "2022-01": 552,
+                                "2022-02": 623,
+                                "2022-03": 665
+                            },
+                            "Unique_Title_Requests": {
+                                "2022-01": 414,
+                                "2022-02": 467,
+                                "2022-03": 499
+                            }
+                        }
+                    }
+                ],
                 "x-stoplight": {
                     "id": "x21xwoz6858ye"
                 }
             },
             "DR_Performance_Database": {
                 "title": "DR - Performance Database",
+                "examples": [
+                    {
+                        "Limit_Exceeded": {
+                            "2022-01": 47,
+                            "2022-02": 59,
+                            "2022-03": 38
+                        },
+                        "No_License": {
+                            "2022-01": 41,
+                            "2022-02": 77,
+                            "2022-03": 42
+                        },
+                        "Searches_Automated": {
+                            "2022-01": 15888,
+                            "2022-02": 14802,
+                            "2022-03": 15488
+                        },
+                        "Searches_Federated": {
+                            "2022-01": 17178,
+                            "2022-02": 17517,
+                            "2022-03": 18637
+                        },
+                        "Searches_Regular": {
+                            "2022-01": 13878,
+                            "2022-02": 13332,
+                            "2022-03": 19412
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Searches_Automated": {
@@ -9629,6 +10077,40 @@
             },
             "DR_Performance_Other": {
                 "title": "DR - Performance Other",
+                "examples": [
+                    {
+                        "Total_Item_Investigations": {
+                            "2022-01": 1104,
+                            "2022-02": 1246,
+                            "2022-03": 1329
+                        },
+                        "Total_Item_Requests": {
+                            "2022-01": 662,
+                            "2022-02": 748,
+                            "2022-03": 797
+                        },
+                        "Unique_Item_Investigations": {
+                            "2022-01": 828,
+                            "2022-02": 935,
+                            "2022-03": 997
+                        },
+                        "Unique_Item_Requests": {
+                            "2022-01": 497,
+                            "2022-02": 561,
+                            "2022-03": 598
+                        },
+                        "Unique_Title_Investigations": {
+                            "2022-01": 552,
+                            "2022-02": 623,
+                            "2022-03": 665
+                        },
+                        "Unique_Title_Requests": {
+                            "2022-01": 414,
+                            "2022-02": 467,
+                            "2022-03": 499
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Total_Item_Investigations": {
@@ -9858,6 +10340,47 @@
             },
             "DR_D1_Attribute_Performance": {
                 "title": "DR_D1 - Attribute_Performance",
+                "examples": [
+                    {
+                        "Performance": {
+                            "Searches_Automated": {
+                                "2022-01": 15888,
+                                "2022-02": 14802,
+                                "2022-03": 15488
+                            },
+                            "Searches_Federated": {
+                                "2022-01": 17178,
+                                "2022-02": 17517,
+                                "2022-03": 18637
+                            },
+                            "Searches_Regular": {
+                                "2022-01": 13878,
+                                "2022-02": 13332,
+                                "2022-03": 19412
+                            },
+                            "Total_Item_Investigations": {
+                                "2022-01": 17546,
+                                "2022-02": 18074,
+                                "2022-03": 18284
+                            },
+                            "Total_Item_Requests": {
+                                "2022-01": 10528,
+                                "2022-02": 10845,
+                                "2022-03": 10971
+                            },
+                            "Unique_Item_Investigations": {
+                                "2022-01": 13162,
+                                "2022-02": 13558,
+                                "2022-03": 13714
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 7897,
+                                "2022-02": 8136,
+                                "2022-03": 8229
+                            }
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Performance": {
@@ -9877,6 +10400,45 @@
             },
             "DR_D1_Performance": {
                 "title": "DR_D1 - Performance",
+                "examples": [
+                    {
+                        "Searches_Automated": {
+                            "2022-01": 15888,
+                            "2022-02": 14802,
+                            "2022-03": 15488
+                        },
+                        "Searches_Federated": {
+                            "2022-01": 17178,
+                            "2022-02": 17517,
+                            "2022-03": 18637
+                        },
+                        "Searches_Regular": {
+                            "2022-01": 13878,
+                            "2022-02": 13332,
+                            "2022-03": 19412
+                        },
+                        "Total_Item_Investigations": {
+                            "2022-01": 17546,
+                            "2022-02": 18074,
+                            "2022-03": 18284
+                        },
+                        "Total_Item_Requests": {
+                            "2022-01": 10528,
+                            "2022-02": 10845,
+                            "2022-03": 10971
+                        },
+                        "Unique_Item_Investigations": {
+                            "2022-01": 13162,
+                            "2022-02": 13558,
+                            "2022-03": 13714
+                        },
+                        "Unique_Item_Requests": {
+                            "2022-01": 7897,
+                            "2022-02": 8136,
+                            "2022-03": 8229
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Searches_Automated": {
@@ -10074,6 +10636,22 @@
             },
             "DR_D2_Attribute_Performance": {
                 "title": "DR_D2 - Attribute_Performance",
+                "examples": [
+                    {
+                        "Performance": {
+                            "Limit_Exceeded": {
+                                "2022-01": 47,
+                                "2022-02": 59,
+                                "2022-03": 38
+                            },
+                            "No_License": {
+                                "2022-01": 41,
+                                "2022-02": 77,
+                                "2022-03": 42
+                            }
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Performance": {
@@ -10093,6 +10671,20 @@
             },
             "DR_D2_Performance": {
                 "title": "DR_D2 - Performance",
+                "examples": [
+                    {
+                        "Limit_Exceeded": {
+                            "2022-01": 47,
+                            "2022-02": 59,
+                            "2022-03": 38
+                        },
+                        "No_License": {
+                            "2022-01": 41,
+                            "2022-02": 77,
+                            "2022-03": 42
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Limit_Exceeded": {
@@ -10246,6 +10838,12 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "TR - Report_Filters",
+                "examples": [
+                    {
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31"
+                    }
+                ],
                 "x-stoplight": {
                     "id": "ikcjo9wyfo37k"
                 },
@@ -10288,6 +10886,15 @@
                 "minProperties": 1,
                 "unevaluatedProperties": false,
                 "title": "TR - Report_Attributes",
+                "examples": [
+                    {
+                        "Attributes_To_Show": [
+                            "YOP",
+                            "Access_Type",
+                            "Access_Method"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "r0nbyyl1j56xk"
                 },
@@ -10452,12 +11059,144 @@
                     "TR - Title Report"
                 ],
                 "title": "TR - Attribute_Performance",
+                "examples": [
+                    {
+                        "Data_Type": "Book",
+                        "YOP": "2022",
+                        "Access_Type": "Controlled",
+                        "Access_Method": "Regular",
+                        "Performance": {
+                            "Limit_Exceeded": {
+                                "2022-01": 49,
+                                "2022-02": 90,
+                                "2022-03": 40
+                            },
+                            "No_License": {
+                                "2022-01": 50,
+                                "2022-02": 84,
+                                "2022-03": 47
+                            },
+                            "Total_Item_Investigations": {
+                                "2022-01": 1104,
+                                "2022-02": 1246,
+                                "2022-03": 1329
+                            },
+                            "Total_Item_Requests": {
+                                "2022-01": 662,
+                                "2022-02": 748,
+                                "2022-03": 797
+                            },
+                            "Unique_Item_Investigations": {
+                                "2022-01": 828,
+                                "2022-02": 935,
+                                "2022-03": 997
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 497,
+                                "2022-02": 561,
+                                "2022-03": 598
+                            },
+                            "Unique_Title_Investigations": {
+                                "2022-01": 552,
+                                "2022-02": 623,
+                                "2022-03": 665
+                            },
+                            "Unique_Title_Requests": {
+                                "2022-01": 414,
+                                "2022-02": 467,
+                                "2022-03": 499
+                            }
+                        }
+                    },
+                    {
+                        "Data_Type": "Journal",
+                        "YOP": "2022",
+                        "Access_Type": "Controlled",
+                        "Access_Method": "Regular",
+                        "Performance": {
+                            "Limit_Exceeded": {
+                                "2022-01": 87,
+                                "2022-02": 88,
+                                "2022-03": 45
+                            },
+                            "No_License": {
+                                "2022-01": 48,
+                                "2022-02": 80,
+                                "2022-03": 37
+                            },
+                            "Total_Item_Investigations": {
+                                "2022-01": 250,
+                                "2022-02": 412,
+                                "2022-03": 406
+                            },
+                            "Total_Item_Requests": {
+                                "2022-01": 150,
+                                "2022-02": 247,
+                                "2022-03": 243
+                            },
+                            "Unique_Item_Investigations": {
+                                "2022-01": 188,
+                                "2022-02": 309,
+                                "2022-03": 304
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 113,
+                                "2022-02": 186,
+                                "2022-03": 183
+                            }
+                        }
+                    }
+                ],
                 "x-stoplight": {
                     "id": "jyaddexytuhwr"
                 }
             },
             "TR_Performance": {
                 "title": "TR - Performance",
+                "examples": [
+                    {
+                        "Limit_Exceeded": {
+                            "2022-01": 49,
+                            "2022-02": 90,
+                            "2022-03": 40
+                        },
+                        "No_License": {
+                            "2022-01": 50,
+                            "2022-02": 84,
+                            "2022-03": 47
+                        },
+                        "Total_Item_Investigations": {
+                            "2022-01": 1104,
+                            "2022-02": 1246,
+                            "2022-03": 1329
+                        },
+                        "Total_Item_Requests": {
+                            "2022-01": 662,
+                            "2022-02": 748,
+                            "2022-03": 797
+                        },
+                        "Unique_Item_Investigations": {
+                            "2022-01": 828,
+                            "2022-02": 935,
+                            "2022-03": 997
+                        },
+                        "Unique_Item_Requests": {
+                            "2022-01": 497,
+                            "2022-02": 561,
+                            "2022-03": 598
+                        },
+                        "Unique_Title_Investigations": {
+                            "2022-01": 552,
+                            "2022-02": 623,
+                            "2022-03": 665
+                        },
+                        "Unique_Title_Requests": {
+                            "2022-01": 414,
+                            "2022-02": 467,
+                            "2022-03": 499
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Total_Item_Investigations": {
@@ -10691,6 +11430,24 @@
             },
             "TR_B1_Attribute_Performance": {
                 "title": "TR_B1 - Attribute_Performance",
+                "examples": [
+                    {
+                        "Data_Type": "Book",
+                        "YOP": "2022",
+                        "Performance": {
+                            "Total_Item_Requests": {
+                                "2022-01": 662,
+                                "2022-02": 748,
+                                "2022-03": 797
+                            },
+                            "Unique_Title_Requests": {
+                                "2022-01": 414,
+                                "2022-02": 467,
+                                "2022-03": 499
+                            }
+                        }
+                    }
+                ],
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
@@ -10723,6 +11480,20 @@
             },
             "TR_B1_Performance": {
                 "title": "TR_B1 - Performance",
+                "examples": [
+                    {
+                        "Total_Item_Requests": {
+                            "2022-01": 662,
+                            "2022-02": 748,
+                            "2022-03": 797
+                        },
+                        "Unique_Title_Requests": {
+                            "2022-01": 414,
+                            "2022-02": 467,
+                            "2022-03": 499
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Total_Item_Requests": {
@@ -10925,6 +11696,24 @@
             },
             "TR_B2_Attribute_Performance": {
                 "title": "TR_B2 - Attribute_Performance",
+                "examples": [
+                    {
+                        "Data_Type": "Book",
+                        "YOP": "2022",
+                        "Performance": {
+                            "Limit_Exceeded": {
+                                "2022-01": 49,
+                                "2022-02": 90,
+                                "2022-03": 40
+                            },
+                            "No_License": {
+                                "2022-01": 50,
+                                "2022-02": 84,
+                                "2022-03": 47
+                            }
+                        }
+                    }
+                ],
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
@@ -10957,6 +11746,20 @@
             },
             "TR_B2_Performance": {
                 "title": "TR_B2 - Performance",
+                "examples": [
+                    {
+                        "Limit_Exceeded": {
+                            "2022-01": 49,
+                            "2022-02": 90,
+                            "2022-03": 40
+                        },
+                        "No_License": {
+                            "2022-01": 50,
+                            "2022-02": 84,
+                            "2022-03": 47
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Limit_Exceeded": {
@@ -11188,6 +11991,45 @@
             },
             "TR_B3_Attribute_Performance": {
                 "title": "TR_B3 - Attribute_Performance",
+                "examples": [
+                    {
+                        "Data_Type": "Book",
+                        "YOP": "2022",
+                        "Access_Type": "Controlled",
+                        "Performance": {
+                            "Total_Item_Investigations": {
+                                "2022-01": 1104,
+                                "2022-02": 1246,
+                                "2022-03": 1329
+                            },
+                            "Total_Item_Requests": {
+                                "2022-01": 662,
+                                "2022-02": 748,
+                                "2022-03": 797
+                            },
+                            "Unique_Item_Investigations": {
+                                "2022-01": 828,
+                                "2022-02": 935,
+                                "2022-03": 997
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 497,
+                                "2022-02": 561,
+                                "2022-03": 598
+                            },
+                            "Unique_Title_Investigations": {
+                                "2022-01": 552,
+                                "2022-02": 623,
+                                "2022-03": 665
+                            },
+                            "Unique_Title_Requests": {
+                                "2022-01": 414,
+                                "2022-02": 467,
+                                "2022-03": 499
+                            }
+                        }
+                    }
+                ],
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
@@ -11224,6 +12066,40 @@
             },
             "TR_B3_Performance": {
                 "title": "TR_B3 - Performance",
+                "examples": [
+                    {
+                        "Total_Item_Investigations": {
+                            "2022-01": 1104,
+                            "2022-02": 1246,
+                            "2022-03": 1329
+                        },
+                        "Total_Item_Requests": {
+                            "2022-01": 662,
+                            "2022-02": 748,
+                            "2022-03": 797
+                        },
+                        "Unique_Item_Investigations": {
+                            "2022-01": 828,
+                            "2022-02": 935,
+                            "2022-03": 997
+                        },
+                        "Unique_Item_Requests": {
+                            "2022-01": 497,
+                            "2022-02": 561,
+                            "2022-03": 598
+                        },
+                        "Unique_Title_Investigations": {
+                            "2022-01": 552,
+                            "2022-02": 623,
+                            "2022-03": 665
+                        },
+                        "Unique_Title_Requests": {
+                            "2022-01": 414,
+                            "2022-02": 467,
+                            "2022-03": 499
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Total_Item_Investigations": {
@@ -11447,6 +12323,22 @@
             },
             "TR_J1_Attribute_Performance": {
                 "title": "TR_J1 - Attribute_Performance",
+                "examples": [
+                    {
+                        "Performance": {
+                            "Total_Item_Requests": {
+                                "2022-01": 357,
+                                "2022-02": 551,
+                                "2022-03": 543
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 283,
+                                "2022-02": 429,
+                                "2022-03": 423
+                            }
+                        }
+                    }
+                ],
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
@@ -11466,6 +12358,20 @@
             },
             "TR_J1_Performance": {
                 "title": "TR_J1 - Performance",
+                "examples": [
+                    {
+                        "Total_Item_Requests": {
+                            "2022-01": 357,
+                            "2022-02": 551,
+                            "2022-03": 543
+                        },
+                        "Unique_Item_Requests": {
+                            "2022-01": 283,
+                            "2022-02": 429,
+                            "2022-03": 423
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Total_Item_Requests": {
@@ -11664,6 +12570,22 @@
             },
             "TR_J2_Attribute_Performance": {
                 "title": "TR_J2 - Attribute_Performance",
+                "examples": [
+                    {
+                        "Performance": {
+                            "Limit_Exceeded": {
+                                "2022-01": 231,
+                                "2022-02": 233,
+                                "2022-03": 147
+                            },
+                            "No_License": {
+                                "2022-01": 153,
+                                "2022-02": 217,
+                                "2022-03": 131
+                            }
+                        }
+                    }
+                ],
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
@@ -11683,6 +12605,20 @@
             },
             "TR_J2_Performance": {
                 "title": "TR_J2 - Performance",
+                "examples": [
+                    {
+                        "Limit_Exceeded": {
+                            "2022-01": 231,
+                            "2022-02": 233,
+                            "2022-03": 147
+                        },
+                        "No_License": {
+                            "2022-01": 153,
+                            "2022-02": 217,
+                            "2022-03": 131
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Limit_Exceeded": {
@@ -11921,6 +12857,33 @@
             },
             "TR_J3_Attribute_Performance": {
                 "title": "TR_J3 - Attribute_Performance",
+                "examples": [
+                    {
+                        "Access_Type": "Controlled",
+                        "Performance": {
+                            "Total_Item_Investigations": {
+                                "2022-01": 557,
+                                "2022-02": 881,
+                                "2022-03": 869
+                            },
+                            "Total_Item_Requests": {
+                                "2022-01": 357,
+                                "2022-02": 551,
+                                "2022-03": 543
+                            },
+                            "Unique_Item_Investigations": {
+                                "2022-01": 433,
+                                "2022-02": 675,
+                                "2022-03": 665
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 283,
+                                "2022-02": 429,
+                                "2022-03": 423
+                            }
+                        }
+                    }
+                ],
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
@@ -11944,6 +12907,30 @@
             },
             "TR_J3_Performance": {
                 "title": "TR_J3 - Performance",
+                "examples": [
+                    {
+                        "Total_Item_Investigations": {
+                            "2022-01": 557,
+                            "2022-02": 881,
+                            "2022-03": 869
+                        },
+                        "Total_Item_Requests": {
+                            "2022-01": 357,
+                            "2022-02": 551,
+                            "2022-03": 543
+                        },
+                        "Unique_Item_Investigations": {
+                            "2022-01": 433,
+                            "2022-02": 675,
+                            "2022-03": 665
+                        },
+                        "Unique_Item_Requests": {
+                            "2022-01": 283,
+                            "2022-02": 429,
+                            "2022-03": 423
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Total_Item_Investigations": {
@@ -12177,6 +13164,23 @@
             },
             "TR_J4_Attribute_Performance": {
                 "title": "TR_J4 - Attribute_Performance",
+                "examples": [
+                    {
+                        "YOP": "2022",
+                        "Performance": {
+                            "Total_Item_Requests": {
+                                "2022-01": 150,
+                                "2022-02": 247,
+                                "2022-03": 243
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 113,
+                                "2022-02": 186,
+                                "2022-03": 183
+                            }
+                        }
+                    }
+                ],
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
@@ -12201,6 +13205,20 @@
             },
             "TR_J4_Performance": {
                 "title": "TR_J4 - Performance",
+                "examples": [
+                    {
+                        "Total_Item_Requests": {
+                            "2022-01": 150,
+                            "2022-02": 247,
+                            "2022-03": 243
+                        },
+                        "Unique_Item_Requests": {
+                            "2022-01": 113,
+                            "2022-02": 186,
+                            "2022-03": 183
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Total_Item_Requests": {
@@ -12368,6 +13386,12 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "IR - Report_Filters",
+                "examples": [
+                    {
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31"
+                    }
+                ],
                 "x-stoplight": {
                     "id": "y0b1afb0y2e5e"
                 },
@@ -12426,6 +13450,19 @@
                 "minProperties": 1,
                 "unevaluatedProperties": false,
                 "title": "IR - Report_Attributes",
+                "examples": [
+                    {
+                        "Attributes_To_Show": [
+                            "Authors",
+                            "Publication_Date",
+                            "Article_Version",
+                            "YOP",
+                            "Access_Type",
+                            "Access_Method"
+                        ],
+                        "Include_Parent_Details": "True"
+                    }
+                ],
                 "x-stoplight": {
                     "id": "8l9n08q64l551"
                 },
@@ -13145,12 +14182,114 @@
                     "IR - Item Report"
                 ],
                 "title": "IR - Attribute_Performance",
+                "examples": [
+                    {
+                        "Data_Type": "Article",
+                        "YOP": "2022",
+                        "Access_Type": "Controlled",
+                        "Access_Method": "Regular",
+                        "Performance": {
+                            "Limit_Exceeded": {
+                                "2022-01": 87,
+                                "2022-02": 88,
+                                "2022-03": 45
+                            },
+                            "No_License": {
+                                "2022-01": 48,
+                                "2022-02": 80,
+                                "2022-03": 37
+                            },
+                            "Total_Item_Investigations": {
+                                "2022-01": 250,
+                                "2022-02": 412,
+                                "2022-03": 406
+                            },
+                            "Total_Item_Requests": {
+                                "2022-01": 150,
+                                "2022-02": 247,
+                                "2022-03": 243
+                            },
+                            "Unique_Item_Investigations": {
+                                "2022-01": 188,
+                                "2022-02": 309,
+                                "2022-03": 304
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 113,
+                                "2022-02": 186,
+                                "2022-03": 183
+                            }
+                        }
+                    },
+                    {
+                        "Data_Type": "Multimedia",
+                        "YOP": "2020",
+                        "Access_Type": "Free_To_Read",
+                        "Access_Method": "Regular",
+                        "Performance": {
+                            "Total_Item_Investigations": {
+                                "2022-01": 1865,
+                                "2022-02": 1891,
+                                "2022-03": 1707
+                            },
+                            "Total_Item_Requests": {
+                                "2022-01": 1119,
+                                "2022-02": 1135,
+                                "2022-03": 1024
+                            },
+                            "Unique_Item_Investigations": {
+                                "2022-01": 1399,
+                                "2022-02": 1418,
+                                "2022-03": 1280
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 839,
+                                "2022-02": 851,
+                                "2022-03": 768
+                            }
+                        }
+                    }
+                ],
                 "x-stoplight": {
                     "id": "2wdfhga85l41l"
                 }
             },
             "IR_Performance": {
                 "title": "IR - Performance",
+                "examples": [
+                    {
+                        "Limit_Exceeded": {
+                            "2022-01": 87,
+                            "2022-02": 88,
+                            "2022-03": 45
+                        },
+                        "No_License": {
+                            "2022-01": 48,
+                            "2022-02": 80,
+                            "2022-03": 37
+                        },
+                        "Total_Item_Investigations": {
+                            "2022-01": 250,
+                            "2022-02": 412,
+                            "2022-03": 406
+                        },
+                        "Total_Item_Requests": {
+                            "2022-01": 150,
+                            "2022-02": 247,
+                            "2022-03": 243
+                        },
+                        "Unique_Item_Investigations": {
+                            "2022-01": 188,
+                            "2022-02": 309,
+                            "2022-03": 304
+                        },
+                        "Unique_Item_Requests": {
+                            "2022-01": 113,
+                            "2022-02": 186,
+                            "2022-03": 183
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Total_Item_Investigations": {
@@ -13647,6 +14786,23 @@
             },
             "IR_A1_Attribute_Performance": {
                 "title": "IR_A1 - Attribute_Performance",
+                "examples": [
+                    {
+                        "Access_Type": "Controlled",
+                        "Performance": {
+                            "Total_Item_Requests": {
+                                "2022-01": 150,
+                                "2022-02": 247,
+                                "2022-03": 243
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 113,
+                                "2022-02": 186,
+                                "2022-03": 183
+                            }
+                        }
+                    }
+                ],
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
@@ -13670,6 +14826,20 @@
             },
             "IR_A1_Performance": {
                 "title": "IR_A1 - Performance",
+                "examples": [
+                    {
+                        "Total_Item_Requests": {
+                            "2022-01": 150,
+                            "2022-02": 247,
+                            "2022-03": 243
+                        },
+                        "Unique_Item_Requests": {
+                            "2022-01": 113,
+                            "2022-02": 186,
+                            "2022-03": 183
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Total_Item_Requests": {
@@ -14065,6 +15235,23 @@
             },
             "IR_M1_Attribute_Performance": {
                 "title": "IR_M1 - Attribute_Performance",
+                "examples": [
+                    {
+                        "Data_Type": "Multimedia",
+                        "Performance": {
+                            "Total_Item_Requests": {
+                                "2022-01": 1119,
+                                "2022-02": 1135,
+                                "2022-03": 1024
+                            },
+                            "Unique_Item_Requests": {
+                                "2022-01": 839,
+                                "2022-02": 851,
+                                "2022-03": 768
+                            }
+                        }
+                    }
+                ],
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
@@ -14095,6 +15282,20 @@
             },
             "IR_M1_Performance": {
                 "title": "IR_M1 - Performance",
+                "examples": [
+                    {
+                        "Total_Item_Requests": {
+                            "2022-01": 1119,
+                            "2022-02": 1135,
+                            "2022-03": 1024
+                        },
+                        "Unique_Item_Requests": {
+                            "2022-01": 839,
+                            "2022-02": 851,
+                            "2022-03": 768
+                        }
+                    }
+                ],
                 "type": "object",
                 "properties": {
                     "Total_Item_Requests": {
@@ -14764,7 +15965,12 @@
                     "id": "sgmqulr0emsi6"
                 },
                 "type": "object",
-                "examples": [],
+                "examples": [
+                    {
+                        "Code": 3030,
+                        "Message": "No Usage Available for Requested Dates"
+                    }
+                ],
                 "properties": {
                     "Code": {
                         "type": "integer",

--- a/api-specification/COUNTER_API.json
+++ b/api-specification/COUNTER_API.json
@@ -7467,6 +7467,32 @@
                         "Platform": "Platform 1",
                         "Attribute_Performance": [
                             {
+                                "Data_Type": "Article",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1461,
+                                        "2022-02": 1704,
+                                        "2022-03": 1475
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 877,
+                                        "2022-02": 1022,
+                                        "2022-03": 885
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1096,
+                                        "2022-02": 1278,
+                                        "2022-03": 1106
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 658,
+                                        "2022-02": 767,
+                                        "2022-03": 664
+                                    }
+                                }
+                            },
+                            {
                                 "Data_Type": "Audiovisual",
                                 "Access_Method": "Regular",
                                 "Performance": {
@@ -7529,6 +7555,84 @@
                                 }
                             },
                             {
+                                "Data_Type": "Book_Segment",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1156,
+                                        "2022-02": 1289,
+                                        "2022-03": 1821
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 694,
+                                        "2022-02": 773,
+                                        "2022-03": 1093
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 867,
+                                        "2022-02": 967,
+                                        "2022-03": 1366
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 521,
+                                        "2022-02": 580,
+                                        "2022-03": 820
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Conference",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1253,
+                                        "2022-02": 1070,
+                                        "2022-03": 1319
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 752,
+                                        "2022-02": 642,
+                                        "2022-03": 791
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 940,
+                                        "2022-02": 803,
+                                        "2022-03": 989
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 564,
+                                        "2022-02": 482,
+                                        "2022-03": 593
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Conference_Item",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1877,
+                                        "2022-02": 1261,
+                                        "2022-03": 1335
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1126,
+                                        "2022-02": 757,
+                                        "2022-03": 801
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1408,
+                                        "2022-02": 946,
+                                        "2022-03": 1001
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 845,
+                                        "2022-02": 568,
+                                        "2022-03": 601
+                                    }
+                                }
+                            },
+                            {
                                 "Data_Type": "Database_Full_Item",
                                 "Access_Method": "Regular",
                                 "Performance": {
@@ -7551,6 +7655,32 @@
                                         "2022-01": 492,
                                         "2022-02": 596,
                                         "2022-03": 779
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Dataset",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1329,
+                                        "2022-02": 1501,
+                                        "2022-03": 1276
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 797,
+                                        "2022-02": 901,
+                                        "2022-03": 766
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 997,
+                                        "2022-02": 1126,
+                                        "2022-03": 957
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 598,
+                                        "2022-02": 676,
+                                        "2022-03": 575
                                     }
                                 }
                             },
@@ -7581,6 +7711,32 @@
                                 }
                             },
                             {
+                                "Data_Type": "Interactive_Resource",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1769,
+                                        "2022-02": 1947,
+                                        "2022-03": 1060
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1061,
+                                        "2022-02": 1168,
+                                        "2022-03": 636
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1327,
+                                        "2022-02": 1460,
+                                        "2022-03": 795
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 796,
+                                        "2022-02": 876,
+                                        "2022-03": 477
+                                    }
+                                }
+                            },
+                            {
                                 "Data_Type": "Journal",
                                 "Access_Method": "Regular",
                                 "Performance": {
@@ -7607,6 +7763,136 @@
                                 }
                             },
                             {
+                                "Data_Type": "Multimedia",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1865,
+                                        "2022-02": 1891,
+                                        "2022-03": 1707
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1119,
+                                        "2022-02": 1135,
+                                        "2022-03": 1024
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1399,
+                                        "2022-02": 1418,
+                                        "2022-03": 1280
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 839,
+                                        "2022-02": 851,
+                                        "2022-03": 768
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "News_Item",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1687,
+                                        "2022-02": 1732,
+                                        "2022-03": 1025
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1012,
+                                        "2022-02": 1039,
+                                        "2022-03": 615
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1265,
+                                        "2022-02": 1299,
+                                        "2022-03": 769
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 759,
+                                        "2022-02": 779,
+                                        "2022-03": 461
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Newspaper_or_Newsletter",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1773,
+                                        "2022-02": 1527,
+                                        "2022-03": 1366
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1064,
+                                        "2022-02": 916,
+                                        "2022-03": 820
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1330,
+                                        "2022-02": 1145,
+                                        "2022-03": 1025
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 798,
+                                        "2022-02": 687,
+                                        "2022-03": 615
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Other",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1730,
+                                        "2022-02": 1263,
+                                        "2022-03": 1787
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1038,
+                                        "2022-02": 758,
+                                        "2022-03": 1072
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1298,
+                                        "2022-02": 947,
+                                        "2022-03": 1340
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 779,
+                                        "2022-02": 569,
+                                        "2022-03": 804
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Patent",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1012,
+                                        "2022-02": 1074,
+                                        "2022-03": 1259
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 607,
+                                        "2022-02": 644,
+                                        "2022-03": 755
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 759,
+                                        "2022-02": 806,
+                                        "2022-03": 944
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 455,
+                                        "2022-02": 483,
+                                        "2022-03": 566
+                                    }
+                                }
+                            },
+                            {
                                 "Data_Type": "Platform",
                                 "Access_Method": "Regular",
                                 "Performance": {
@@ -7614,6 +7900,224 @@
                                         "2022-01": 17484,
                                         "2022-02": 18061,
                                         "2022-03": 17160
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Reference_Item",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1546,
+                                        "2022-02": 1408,
+                                        "2022-03": 1204
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 928,
+                                        "2022-02": 845,
+                                        "2022-03": 722
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1160,
+                                        "2022-02": 1056,
+                                        "2022-03": 903
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 696,
+                                        "2022-02": 634,
+                                        "2022-03": 542
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Reference_Work",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1645,
+                                        "2022-02": 1022,
+                                        "2022-03": 1106
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 987,
+                                        "2022-02": 613,
+                                        "2022-03": 664
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1234,
+                                        "2022-02": 767,
+                                        "2022-03": 830
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 740,
+                                        "2022-02": 460,
+                                        "2022-03": 498
+                                    },
+                                    "Unique_Title_Investigations": {
+                                        "2022-01": 301,
+                                        "2022-02": 283,
+                                        "2022-03": 217
+                                    },
+                                    "Unique_Title_Requests": {
+                                        "2022-01": 226,
+                                        "2022-02": 212,
+                                        "2022-03": 163
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Report",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1381,
+                                        "2022-02": 1852,
+                                        "2022-03": 1726
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 829,
+                                        "2022-02": 1111,
+                                        "2022-03": 1036
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1036,
+                                        "2022-02": 1389,
+                                        "2022-03": 1295
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 622,
+                                        "2022-02": 833,
+                                        "2022-03": 777
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Software",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1187,
+                                        "2022-02": 1775,
+                                        "2022-03": 1416
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 712,
+                                        "2022-02": 1065,
+                                        "2022-03": 850
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 890,
+                                        "2022-02": 1331,
+                                        "2022-03": 1062
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 534,
+                                        "2022-02": 799,
+                                        "2022-03": 638
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Sound",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1460,
+                                        "2022-02": 1905,
+                                        "2022-03": 1777
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 876,
+                                        "2022-02": 1143,
+                                        "2022-03": 1066
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1095,
+                                        "2022-02": 1429,
+                                        "2022-03": 1333
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 657,
+                                        "2022-02": 857,
+                                        "2022-03": 800
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Standard",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1800,
+                                        "2022-02": 1721,
+                                        "2022-03": 1251
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1080,
+                                        "2022-02": 1033,
+                                        "2022-03": 751
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1350,
+                                        "2022-02": 1291,
+                                        "2022-03": 938
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 810,
+                                        "2022-02": 775,
+                                        "2022-03": 563
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Thesis_or_Dissertation",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1970,
+                                        "2022-02": 1930,
+                                        "2022-03": 1981
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1182,
+                                        "2022-02": 1158,
+                                        "2022-03": 1189
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1478,
+                                        "2022-02": 1448,
+                                        "2022-03": 1486
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 887,
+                                        "2022-02": 869,
+                                        "2022-03": 892
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Unspecified",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1011,
+                                        "2022-02": 1828,
+                                        "2022-03": 1830
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 607,
+                                        "2022-02": 1097,
+                                        "2022-03": 1098
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 758,
+                                        "2022-02": 1371,
+                                        "2022-03": 1373
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 455,
+                                        "2022-02": 823,
+                                        "2022-03": 824
                                     }
                                 }
                             }
@@ -7909,6 +8413,21 @@
                         "Platform": "Platform 1",
                         "Attribute_Performance": [
                             {
+                                "Data_Type": "Article",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 877,
+                                        "2022-02": 1022,
+                                        "2022-03": 885
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 658,
+                                        "2022-02": 767,
+                                        "2022-03": 664
+                                    }
+                                }
+                            },
+                            {
                                 "Data_Type": "Audiovisual",
                                 "Performance": {
                                     "Total_Item_Requests": {
@@ -7944,6 +8463,51 @@
                                 }
                             },
                             {
+                                "Data_Type": "Book_Segment",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 694,
+                                        "2022-02": 773,
+                                        "2022-03": 1093
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 521,
+                                        "2022-02": 580,
+                                        "2022-03": 820
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Conference",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 752,
+                                        "2022-02": 642,
+                                        "2022-03": 791
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 564,
+                                        "2022-02": 482,
+                                        "2022-03": 593
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Conference_Item",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1126,
+                                        "2022-02": 757,
+                                        "2022-03": 801
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 845,
+                                        "2022-02": 568,
+                                        "2022-03": 601
+                                    }
+                                }
+                            },
+                            {
                                 "Data_Type": "Database_Full_Item",
                                 "Performance": {
                                     "Total_Item_Requests": {
@@ -7955,6 +8519,21 @@
                                         "2022-01": 492,
                                         "2022-02": 596,
                                         "2022-03": 779
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Dataset",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 797,
+                                        "2022-02": 901,
+                                        "2022-03": 766
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 598,
+                                        "2022-02": 676,
+                                        "2022-03": 575
                                     }
                                 }
                             },
@@ -7974,6 +8553,21 @@
                                 }
                             },
                             {
+                                "Data_Type": "Interactive_Resource",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1061,
+                                        "2022-02": 1168,
+                                        "2022-03": 636
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 796,
+                                        "2022-02": 876,
+                                        "2022-03": 477
+                                    }
+                                }
+                            },
+                            {
                                 "Data_Type": "Journal",
                                 "Performance": {
                                     "Total_Item_Requests": {
@@ -7989,12 +8583,212 @@
                                 }
                             },
                             {
+                                "Data_Type": "Multimedia",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1119,
+                                        "2022-02": 1135,
+                                        "2022-03": 1024
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 839,
+                                        "2022-02": 851,
+                                        "2022-03": 768
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "News_Item",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1012,
+                                        "2022-02": 1039,
+                                        "2022-03": 615
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 759,
+                                        "2022-02": 779,
+                                        "2022-03": 461
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Newspaper_or_Newsletter",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1064,
+                                        "2022-02": 916,
+                                        "2022-03": 820
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 798,
+                                        "2022-02": 687,
+                                        "2022-03": 615
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Other",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1038,
+                                        "2022-02": 758,
+                                        "2022-03": 1072
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 779,
+                                        "2022-02": 569,
+                                        "2022-03": 804
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Patent",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 607,
+                                        "2022-02": 644,
+                                        "2022-03": 755
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 455,
+                                        "2022-02": 483,
+                                        "2022-03": 566
+                                    }
+                                }
+                            },
+                            {
                                 "Data_Type": "Platform",
                                 "Performance": {
                                     "Searches_Platform": {
                                         "2022-01": 17484,
                                         "2022-02": 18061,
                                         "2022-03": 17160
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Reference_Item",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 928,
+                                        "2022-02": 845,
+                                        "2022-03": 722
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 696,
+                                        "2022-02": 634,
+                                        "2022-03": 542
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Reference_Work",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 987,
+                                        "2022-02": 613,
+                                        "2022-03": 664
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 740,
+                                        "2022-02": 460,
+                                        "2022-03": 498
+                                    },
+                                    "Unique_Title_Requests": {
+                                        "2022-01": 226,
+                                        "2022-02": 212,
+                                        "2022-03": 163
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Report",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 829,
+                                        "2022-02": 1111,
+                                        "2022-03": 1036
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 622,
+                                        "2022-02": 833,
+                                        "2022-03": 777
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Software",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 712,
+                                        "2022-02": 1065,
+                                        "2022-03": 850
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 534,
+                                        "2022-02": 799,
+                                        "2022-03": 638
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Sound",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 876,
+                                        "2022-02": 1143,
+                                        "2022-03": 1066
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 657,
+                                        "2022-02": 857,
+                                        "2022-03": 800
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Standard",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1080,
+                                        "2022-02": 1033,
+                                        "2022-03": 751
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 810,
+                                        "2022-02": 775,
+                                        "2022-03": 563
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Thesis_or_Dissertation",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1182,
+                                        "2022-02": 1158,
+                                        "2022-03": 1189
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 887,
+                                        "2022-02": 869,
+                                        "2022-03": 892
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Unspecified",
+                                "Performance": {
+                                    "Total_Item_Requests": {
+                                        "2022-01": 607,
+                                        "2022-02": 1097,
+                                        "2022-03": 1098
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 455,
+                                        "2022-02": 823,
+                                        "2022-03": 824
                                     }
                                 }
                             }
@@ -8384,6 +9178,32 @@
                                 }
                             },
                             {
+                                "Data_Type": "Conference",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1253,
+                                        "2022-02": 1070,
+                                        "2022-03": 1319
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 752,
+                                        "2022-02": 642,
+                                        "2022-03": 791
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 940,
+                                        "2022-02": 803,
+                                        "2022-03": 989
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 564,
+                                        "2022-02": 482,
+                                        "2022-03": 593
+                                    }
+                                }
+                            },
+                            {
                                 "Data_Type": "Database_Aggregated",
                                 "Access_Method": "Regular",
                                 "Performance": {
@@ -8401,6 +9221,11 @@
                                         "2022-01": 15888,
                                         "2022-02": 14802,
                                         "2022-03": 15488
+                                    },
+                                    "Searches_Federated": {
+                                        "2022-01": 17178,
+                                        "2022-02": 17517,
+                                        "2022-03": 18637
                                     },
                                     "Searches_Regular": {
                                         "2022-01": 13878,
@@ -8432,6 +9257,250 @@
                                         "2022-01": 451,
                                         "2022-02": 743,
                                         "2022-03": 731
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Multimedia",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1865,
+                                        "2022-02": 1891,
+                                        "2022-03": 1707
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1119,
+                                        "2022-02": 1135,
+                                        "2022-03": 1024
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1399,
+                                        "2022-02": 1418,
+                                        "2022-03": 1280
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 839,
+                                        "2022-02": 851,
+                                        "2022-03": 768
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Newspaper_or_Newsletter",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1773,
+                                        "2022-02": 1527,
+                                        "2022-03": 1366
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1064,
+                                        "2022-02": 916,
+                                        "2022-03": 820
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1330,
+                                        "2022-02": 1145,
+                                        "2022-03": 1025
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 798,
+                                        "2022-02": 687,
+                                        "2022-03": 615
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Other",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1730,
+                                        "2022-02": 1263,
+                                        "2022-03": 1787
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1038,
+                                        "2022-02": 758,
+                                        "2022-03": 1072
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1298,
+                                        "2022-02": 947,
+                                        "2022-03": 1340
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 779,
+                                        "2022-02": 569,
+                                        "2022-03": 804
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Patent",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1012,
+                                        "2022-02": 1074,
+                                        "2022-03": 1259
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 607,
+                                        "2022-02": 644,
+                                        "2022-03": 755
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 759,
+                                        "2022-02": 806,
+                                        "2022-03": 944
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 455,
+                                        "2022-02": 483,
+                                        "2022-03": 566
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Reference_Work",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1645,
+                                        "2022-02": 1022,
+                                        "2022-03": 1106
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 987,
+                                        "2022-02": 613,
+                                        "2022-03": 664
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1234,
+                                        "2022-02": 767,
+                                        "2022-03": 830
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 740,
+                                        "2022-02": 460,
+                                        "2022-03": 498
+                                    },
+                                    "Unique_Title_Investigations": {
+                                        "2022-01": 301,
+                                        "2022-02": 283,
+                                        "2022-03": 217
+                                    },
+                                    "Unique_Title_Requests": {
+                                        "2022-01": 226,
+                                        "2022-02": 212,
+                                        "2022-03": 163
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Report",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1381,
+                                        "2022-02": 1852,
+                                        "2022-03": 1726
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 829,
+                                        "2022-02": 1111,
+                                        "2022-03": 1036
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1036,
+                                        "2022-02": 1389,
+                                        "2022-03": 1295
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 622,
+                                        "2022-02": 833,
+                                        "2022-03": 777
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Standard",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1800,
+                                        "2022-02": 1721,
+                                        "2022-03": 1251
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1080,
+                                        "2022-02": 1033,
+                                        "2022-03": 751
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1350,
+                                        "2022-02": 1291,
+                                        "2022-03": 938
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 810,
+                                        "2022-02": 775,
+                                        "2022-03": 563
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Thesis_or_Dissertation",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1970,
+                                        "2022-02": 1930,
+                                        "2022-03": 1981
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 1182,
+                                        "2022-02": 1158,
+                                        "2022-03": 1189
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 1478,
+                                        "2022-02": 1448,
+                                        "2022-03": 1486
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 887,
+                                        "2022-02": 869,
+                                        "2022-03": 892
+                                    }
+                                }
+                            },
+                            {
+                                "Data_Type": "Unspecified",
+                                "Access_Method": "Regular",
+                                "Performance": {
+                                    "Total_Item_Investigations": {
+                                        "2022-01": 1011,
+                                        "2022-02": 1828,
+                                        "2022-03": 1830
+                                    },
+                                    "Total_Item_Requests": {
+                                        "2022-01": 607,
+                                        "2022-02": 1097,
+                                        "2022-03": 1098
+                                    },
+                                    "Unique_Item_Investigations": {
+                                        "2022-01": 758,
+                                        "2022-02": 1371,
+                                        "2022-03": 1373
+                                    },
+                                    "Unique_Item_Requests": {
+                                        "2022-01": 455,
+                                        "2022-02": 823,
+                                        "2022-03": 824
                                     }
                                 }
                             }
@@ -8747,34 +9816,39 @@
                             {
                                 "Performance": {
                                     "Searches_Automated": {
-                                        "2022-01": 31000,
-                                        "2022-02": 33636,
-                                        "2022-03": 32681
+                                        "2022-01": 15888,
+                                        "2022-02": 14802,
+                                        "2022-03": 15488
+                                    },
+                                    "Searches_Federated": {
+                                        "2022-01": 17178,
+                                        "2022-02": 17517,
+                                        "2022-03": 18637
                                     },
                                     "Searches_Regular": {
-                                        "2022-01": 29408,
-                                        "2022-02": 30185,
-                                        "2022-03": 36765
+                                        "2022-01": 13878,
+                                        "2022-02": 13332,
+                                        "2022-03": 19412
                                     },
                                     "Total_Item_Investigations": {
-                                        "2022-01": 35725,
-                                        "2022-02": 37133,
-                                        "2022-03": 35980
+                                        "2022-01": 17546,
+                                        "2022-02": 18074,
+                                        "2022-03": 18284
                                     },
                                     "Total_Item_Requests": {
-                                        "2022-01": 21436,
-                                        "2022-02": 22282,
-                                        "2022-03": 21588
+                                        "2022-01": 10528,
+                                        "2022-02": 10845,
+                                        "2022-03": 10971
                                     },
                                     "Unique_Item_Investigations": {
-                                        "2022-01": 27068,
-                                        "2022-02": 27780,
-                                        "2022-03": 27063
+                                        "2022-01": 13162,
+                                        "2022-02": 13558,
+                                        "2022-03": 13714
                                     },
                                     "Unique_Item_Requests": {
-                                        "2022-01": 16199,
-                                        "2022-02": 16847,
-                                        "2022-03": 16338
+                                        "2022-01": 7897,
+                                        "2022-02": 8136,
+                                        "2022-03": 8229
                                     }
                                 }
                             }
@@ -8983,14 +10057,14 @@
                             {
                                 "Performance": {
                                     "Limit_Exceeded": {
-                                        "2022-01": 70,
-                                        "2022-02": 93,
-                                        "2022-03": 112
+                                        "2022-01": 47,
+                                        "2022-02": 59,
+                                        "2022-03": 38
                                     },
                                     "No_License": {
-                                        "2022-01": 94,
-                                        "2022-02": 94,
-                                        "2022-03": 104
+                                        "2022-01": 41,
+                                        "2022-02": 77,
+                                        "2022-03": 42
                                     }
                                 }
                             }
@@ -10356,14 +11430,14 @@
                             {
                                 "Performance": {
                                     "Total_Item_Requests": {
-                                        "2022-01": 526,
-                                        "2022-02": 866,
-                                        "2022-03": 852
+                                        "2022-01": 357,
+                                        "2022-02": 551,
+                                        "2022-03": 543
                                     },
                                     "Unique_Item_Requests": {
-                                        "2022-01": 226,
-                                        "2022-02": 372,
-                                        "2022-03": 366
+                                        "2022-01": 283,
+                                        "2022-02": 429,
+                                        "2022-03": 423
                                     }
                                 }
                             }
@@ -10573,14 +11647,14 @@
                             {
                                 "Performance": {
                                     "Limit_Exceeded": {
-                                        "2022-01": 174,
-                                        "2022-02": 176,
-                                        "2022-03": 90
+                                        "2022-01": 231,
+                                        "2022-02": 233,
+                                        "2022-03": 147
                                     },
                                     "No_License": {
-                                        "2022-01": 96,
-                                        "2022-02": 160,
-                                        "2022-03": 74
+                                        "2022-01": 153,
+                                        "2022-02": 217,
+                                        "2022-03": 131
                                     }
                                 }
                             }
@@ -10795,24 +11869,24 @@
                                 "Access_Type": "Controlled",
                                 "Performance": {
                                     "Total_Item_Investigations": {
-                                        "2022-01": 500,
-                                        "2022-02": 824,
-                                        "2022-03": 812
+                                        "2022-01": 557,
+                                        "2022-02": 881,
+                                        "2022-03": 869
                                     },
                                     "Total_Item_Requests": {
-                                        "2022-01": 300,
-                                        "2022-02": 494,
-                                        "2022-03": 486
+                                        "2022-01": 357,
+                                        "2022-02": 551,
+                                        "2022-03": 543
                                     },
                                     "Unique_Item_Investigations": {
-                                        "2022-01": 376,
-                                        "2022-02": 618,
-                                        "2022-03": 608
+                                        "2022-01": 433,
+                                        "2022-02": 675,
+                                        "2022-03": 665
                                     },
                                     "Unique_Item_Requests": {
-                                        "2022-01": 226,
-                                        "2022-02": 372,
-                                        "2022-03": 366
+                                        "2022-01": 283,
+                                        "2022-02": 429,
+                                        "2022-03": 423
                                     }
                                 }
                             },
@@ -10820,24 +11894,24 @@
                                 "Access_Type": "Open",
                                 "Performance": {
                                     "Total_Item_Investigations": {
-                                        "2022-01": 1504,
-                                        "2022-02": 2476,
-                                        "2022-03": 2434
+                                        "2022-01": 1565,
+                                        "2022-02": 2537,
+                                        "2022-03": 2495
                                     },
                                     "Total_Item_Requests": {
-                                        "2022-01": 902,
-                                        "2022-02": 1486,
-                                        "2022-03": 1462
+                                        "2022-01": 963,
+                                        "2022-02": 1547,
+                                        "2022-03": 1523
                                     },
                                     "Unique_Item_Investigations": {
-                                        "2022-01": 1128,
-                                        "2022-02": 1858,
-                                        "2022-03": 1826
+                                        "2022-01": 1189,
+                                        "2022-02": 1919,
+                                        "2022-03": 1887
                                     },
                                     "Unique_Item_Requests": {
-                                        "2022-01": 676,
-                                        "2022-02": 1114,
-                                        "2022-03": 1096
+                                        "2022-01": 737,
+                                        "2022-02": 1175,
+                                        "2022-03": 1157
                                     }
                                 }
                             }
@@ -11086,14 +12160,14 @@
                                 "YOP": "2021",
                                 "Performance": {
                                     "Total_Item_Requests": {
-                                        "2022-01": 150,
-                                        "2022-02": 247,
-                                        "2022-03": 243
+                                        "2022-01": 207,
+                                        "2022-02": 304,
+                                        "2022-03": 300
                                     },
                                     "Unique_Item_Requests": {
-                                        "2022-01": 113,
-                                        "2022-02": 186,
-                                        "2022-03": 183
+                                        "2022-01": 170,
+                                        "2022-02": 243,
+                                        "2022-03": 240
                                     }
                                 }
                             }
@@ -11541,7 +12615,7 @@
                                 ]
                             },
                             {
-                                "Item": "Item 2",
+                                "Item": "Item 4",
                                 "Publisher": "Sample Publisher",
                                 "Publisher_ID": {
                                     "ISNI": [
@@ -11551,58 +12625,58 @@
                                 "Platform": "Platform 1",
                                 "Authors": [
                                     {
-                                        "Name": "Author 2"
+                                        "Name": "Author 4"
                                     }
                                 ],
-                                "Publication_Date": "2021-02-21",
+                                "Publication_Date": "2019-08-17",
                                 "Item_ID": {
-                                    "DOI": "10.9999/xxxxi02",
-                                    "Proprietary": "P1:I02",
-                                    "URI": "https://doi.org/10.9999/xxxxi02"
+                                    "DOI": "10.9999/xxxxi04",
+                                    "Proprietary": "P1:I04",
+                                    "URI": "https://doi.org/10.9999/xxxxi04"
                                 },
                                 "Attribute_Performance": [
                                     {
-                                        "Data_Type": "Audiovisual",
-                                        "YOP": "2021",
+                                        "Data_Type": "Book_Segment",
+                                        "YOP": "2019",
                                         "Access_Type": "Controlled",
                                         "Access_Method": "Regular",
                                         "Performance": {
                                             "Limit_Exceeded": {
-                                                "2022-01": 53,
-                                                "2022-02": 53,
-                                                "2022-03": 64
+                                                "2022-01": 50,
+                                                "2022-02": 43,
+                                                "2022-03": 68
                                             },
                                             "No_License": {
-                                                "2022-01": 30,
-                                                "2022-02": 90,
+                                                "2022-01": 33,
+                                                "2022-02": 68,
                                                 "2022-03": 58
                                             },
                                             "Total_Item_Investigations": {
-                                                "2022-01": 1279,
-                                                "2022-02": 1323,
-                                                "2022-03": 1826
+                                                "2022-01": 1156,
+                                                "2022-02": 1289,
+                                                "2022-03": 1821
                                             },
                                             "Total_Item_Requests": {
-                                                "2022-01": 767,
-                                                "2022-02": 794,
-                                                "2022-03": 1096
+                                                "2022-01": 694,
+                                                "2022-02": 773,
+                                                "2022-03": 1093
                                             },
                                             "Unique_Item_Investigations": {
-                                                "2022-01": 959,
-                                                "2022-02": 992,
-                                                "2022-03": 1370
+                                                "2022-01": 867,
+                                                "2022-02": 967,
+                                                "2022-03": 1366
                                             },
                                             "Unique_Item_Requests": {
-                                                "2022-01": 575,
-                                                "2022-02": 596,
-                                                "2022-03": 822
+                                                "2022-01": 521,
+                                                "2022-02": 580,
+                                                "2022-03": 820
                                             }
                                         }
                                     }
                                 ]
                             },
                             {
-                                "Item": "Item 9",
+                                "Item": "Item 6",
                                 "Publisher": "Sample Publisher",
                                 "Publisher_ID": {
                                     "ISNI": [
@@ -11612,51 +12686,306 @@
                                 "Platform": "Platform 1",
                                 "Authors": [
                                     {
-                                        "Name": "Author 9"
+                                        "Name": "Author 6"
                                     }
                                 ],
-                                "Publication_Date": "2019-08-26",
+                                "Publication_Date": "2020-08-09",
                                 "Item_ID": {
-                                    "DOI": "10.9999/xxxxi09",
-                                    "Proprietary": "P1:I09",
-                                    "URI": "https://doi.org/10.9999/xxxxi09"
+                                    "DOI": "10.9999/xxxxi06",
+                                    "Proprietary": "P1:I06",
+                                    "URI": "https://doi.org/10.9999/xxxxi06"
                                 },
                                 "Attribute_Performance": [
                                     {
-                                        "Data_Type": "Image",
+                                        "Data_Type": "Conference_Item",
+                                        "YOP": "2020",
+                                        "Access_Type": "Free_To_Read",
+                                        "Access_Method": "Regular",
+                                        "Performance": {
+                                            "Total_Item_Investigations": {
+                                                "2022-01": 1877,
+                                                "2022-02": 1261,
+                                                "2022-03": 1335
+                                            },
+                                            "Total_Item_Requests": {
+                                                "2022-01": 1126,
+                                                "2022-02": 757,
+                                                "2022-03": 801
+                                            },
+                                            "Unique_Item_Investigations": {
+                                                "2022-01": 1408,
+                                                "2022-02": 946,
+                                                "2022-03": 1001
+                                            },
+                                            "Unique_Item_Requests": {
+                                                "2022-01": 845,
+                                                "2022-02": 568,
+                                                "2022-03": 601
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "Item": "Item 8",
+                                "Publisher": "Sample Publisher",
+                                "Publisher_ID": {
+                                    "ISNI": [
+                                        "4321432143214321"
+                                    ]
+                                },
+                                "Platform": "Platform 1",
+                                "Authors": [
+                                    {
+                                        "Name": "Author 8"
+                                    }
+                                ],
+                                "Publication_Date": "2020-09-10",
+                                "Item_ID": {
+                                    "DOI": "10.9999/xxxxi08",
+                                    "Proprietary": "P1:I08",
+                                    "URI": "https://doi.org/10.9999/xxxxi08"
+                                },
+                                "Attribute_Performance": [
+                                    {
+                                        "Data_Type": "Dataset",
+                                        "YOP": "2020",
+                                        "Access_Type": "Open",
+                                        "Access_Method": "Regular",
+                                        "Performance": {
+                                            "Total_Item_Investigations": {
+                                                "2022-01": 1329,
+                                                "2022-02": 1501,
+                                                "2022-03": 1276
+                                            },
+                                            "Total_Item_Requests": {
+                                                "2022-01": 797,
+                                                "2022-02": 901,
+                                                "2022-03": 766
+                                            },
+                                            "Unique_Item_Investigations": {
+                                                "2022-01": 997,
+                                                "2022-02": 1126,
+                                                "2022-03": 957
+                                            },
+                                            "Unique_Item_Requests": {
+                                                "2022-01": 598,
+                                                "2022-02": 676,
+                                                "2022-03": 575
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "Item": "Item 14",
+                                "Publisher": "Sample Publisher",
+                                "Publisher_ID": {
+                                    "ISNI": [
+                                        "4321432143214321"
+                                    ]
+                                },
+                                "Platform": "Platform 1",
+                                "Authors": [
+                                    {
+                                        "Name": "Author 14"
+                                    }
+                                ],
+                                "Publication_Date": "2018-01-13",
+                                "Item_ID": {
+                                    "DOI": "10.9999/xxxxi14",
+                                    "Proprietary": "P1:I14",
+                                    "URI": "https://doi.org/10.9999/xxxxi14"
+                                },
+                                "Attribute_Performance": [
+                                    {
+                                        "Data_Type": "News_Item",
+                                        "YOP": "2018",
+                                        "Access_Type": "Free_To_Read",
+                                        "Access_Method": "Regular",
+                                        "Performance": {
+                                            "Total_Item_Investigations": {
+                                                "2022-01": 1687,
+                                                "2022-02": 1732,
+                                                "2022-03": 1025
+                                            },
+                                            "Total_Item_Requests": {
+                                                "2022-01": 1012,
+                                                "2022-02": 1039,
+                                                "2022-03": 615
+                                            },
+                                            "Unique_Item_Investigations": {
+                                                "2022-01": 1265,
+                                                "2022-02": 1299,
+                                                "2022-03": 769
+                                            },
+                                            "Unique_Item_Requests": {
+                                                "2022-01": 759,
+                                                "2022-02": 779,
+                                                "2022-03": 461
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "Item": "Item 16",
+                                "Publisher": "Sample Publisher",
+                                "Publisher_ID": {
+                                    "ISNI": [
+                                        "4321432143214321"
+                                    ]
+                                },
+                                "Platform": "Platform 1",
+                                "Authors": [
+                                    {
+                                        "Name": "Author 16"
+                                    }
+                                ],
+                                "Publication_Date": "2019-11-01",
+                                "Item_ID": {
+                                    "DOI": "10.9999/xxxxi16",
+                                    "Proprietary": "P1:I16",
+                                    "URI": "https://doi.org/10.9999/xxxxi16"
+                                },
+                                "Attribute_Performance": [
+                                    {
+                                        "Data_Type": "Other",
                                         "YOP": "2019",
+                                        "Access_Type": "Free_To_Read",
+                                        "Access_Method": "Regular",
+                                        "Performance": {
+                                            "Total_Item_Investigations": {
+                                                "2022-01": 1730,
+                                                "2022-02": 1263,
+                                                "2022-03": 1787
+                                            },
+                                            "Total_Item_Requests": {
+                                                "2022-01": 1038,
+                                                "2022-02": 758,
+                                                "2022-03": 1072
+                                            },
+                                            "Unique_Item_Investigations": {
+                                                "2022-01": 1298,
+                                                "2022-02": 947,
+                                                "2022-03": 1340
+                                            },
+                                            "Unique_Item_Requests": {
+                                                "2022-01": 779,
+                                                "2022-02": 569,
+                                                "2022-03": 804
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "Item": "Item 18",
+                                "Publisher": "Sample Publisher",
+                                "Publisher_ID": {
+                                    "ISNI": [
+                                        "4321432143214321"
+                                    ]
+                                },
+                                "Platform": "Platform 1",
+                                "Authors": [
+                                    {
+                                        "Name": "Author 18"
+                                    }
+                                ],
+                                "Publication_Date": "2021-09-03",
+                                "Item_ID": {
+                                    "DOI": "10.9999/xxxxi18",
+                                    "Proprietary": "P1:I18",
+                                    "URI": "https://doi.org/10.9999/xxxxi18"
+                                },
+                                "Attribute_Performance": [
+                                    {
+                                        "Data_Type": "Reference_Item",
+                                        "YOP": "2021",
+                                        "Access_Type": "Open",
+                                        "Access_Method": "Regular",
+                                        "Performance": {
+                                            "Total_Item_Investigations": {
+                                                "2022-01": 1546,
+                                                "2022-02": 1408,
+                                                "2022-03": 1204
+                                            },
+                                            "Total_Item_Requests": {
+                                                "2022-01": 928,
+                                                "2022-02": 845,
+                                                "2022-03": 722
+                                            },
+                                            "Unique_Item_Investigations": {
+                                                "2022-01": 1160,
+                                                "2022-02": 1056,
+                                                "2022-03": 903
+                                            },
+                                            "Unique_Item_Requests": {
+                                                "2022-01": 696,
+                                                "2022-02": 634,
+                                                "2022-03": 542
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "Item": "Item 21",
+                                "Publisher": "Sample Publisher",
+                                "Publisher_ID": {
+                                    "ISNI": [
+                                        "4321432143214321"
+                                    ]
+                                },
+                                "Platform": "Platform 1",
+                                "Authors": [
+                                    {
+                                        "Name": "Author 21"
+                                    }
+                                ],
+                                "Publication_Date": "2020-02-08",
+                                "Item_ID": {
+                                    "DOI": "10.9999/xxxxi21",
+                                    "Proprietary": "P1:I21",
+                                    "URI": "https://doi.org/10.9999/xxxxi21"
+                                },
+                                "Attribute_Performance": [
+                                    {
+                                        "Data_Type": "Software",
+                                        "YOP": "2020",
                                         "Access_Type": "Controlled",
                                         "Access_Method": "Regular",
                                         "Performance": {
                                             "Limit_Exceeded": {
-                                                "2022-01": 45,
-                                                "2022-02": 47,
-                                                "2022-03": 41
+                                                "2022-01": 43,
+                                                "2022-02": 59,
+                                                "2022-03": 38
                                             },
                                             "No_License": {
-                                                "2022-01": 44,
-                                                "2022-02": 76,
-                                                "2022-03": 64
+                                                "2022-01": 31,
+                                                "2022-02": 44,
+                                                "2022-03": 61
                                             },
                                             "Total_Item_Investigations": {
-                                                "2022-01": 1732,
-                                                "2022-02": 1194,
-                                                "2022-03": 1867
+                                                "2022-01": 1187,
+                                                "2022-02": 1775,
+                                                "2022-03": 1416
                                             },
                                             "Total_Item_Requests": {
-                                                "2022-01": 1039,
-                                                "2022-02": 716,
-                                                "2022-03": 1120
+                                                "2022-01": 712,
+                                                "2022-02": 1065,
+                                                "2022-03": 850
                                             },
                                             "Unique_Item_Investigations": {
-                                                "2022-01": 1299,
-                                                "2022-02": 896,
-                                                "2022-03": 1400
+                                                "2022-01": 890,
+                                                "2022-02": 1331,
+                                                "2022-03": 1062
                                             },
                                             "Unique_Item_Requests": {
-                                                "2022-01": 779,
-                                                "2022-02": 537,
-                                                "2022-03": 840
+                                                "2022-01": 534,
+                                                "2022-02": 799,
+                                                "2022-03": 638
                                             }
                                         }
                                     }
@@ -12565,6 +13894,102 @@
                                                 "2022-01": 779,
                                                 "2022-02": 537,
                                                 "2022-03": 840
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "Item": "Item 10",
+                                "Publisher": "Sample Publisher",
+                                "Publisher_ID": {
+                                    "ISNI": [
+                                        "4321432143214321"
+                                    ]
+                                },
+                                "Platform": "Platform 1",
+                                "Item_ID": {
+                                    "DOI": "10.9999/xxxxi10",
+                                    "Proprietary": "P1:I10",
+                                    "URI": "https://doi.org/10.9999/xxxxi10"
+                                },
+                                "Attribute_Performance": [
+                                    {
+                                        "Data_Type": "Interactive_Resource",
+                                        "Performance": {
+                                            "Total_Item_Requests": {
+                                                "2022-01": 1061,
+                                                "2022-02": 1168,
+                                                "2022-03": 636
+                                            },
+                                            "Unique_Item_Requests": {
+                                                "2022-01": 796,
+                                                "2022-02": 876,
+                                                "2022-03": 477
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "Item": "Item 13",
+                                "Publisher": "Sample Publisher",
+                                "Publisher_ID": {
+                                    "ISNI": [
+                                        "4321432143214321"
+                                    ]
+                                },
+                                "Platform": "Platform 1",
+                                "Item_ID": {
+                                    "DOI": "10.9999/xxxxi13",
+                                    "Proprietary": "P1:I13",
+                                    "URI": "https://doi.org/10.9999/xxxxi13"
+                                },
+                                "Attribute_Performance": [
+                                    {
+                                        "Data_Type": "Multimedia",
+                                        "Performance": {
+                                            "Total_Item_Requests": {
+                                                "2022-01": 1119,
+                                                "2022-02": 1135,
+                                                "2022-03": 1024
+                                            },
+                                            "Unique_Item_Requests": {
+                                                "2022-01": 839,
+                                                "2022-02": 851,
+                                                "2022-03": 768
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "Item": "Item 22",
+                                "Publisher": "Sample Publisher",
+                                "Publisher_ID": {
+                                    "ISNI": [
+                                        "4321432143214321"
+                                    ]
+                                },
+                                "Platform": "Platform 1",
+                                "Item_ID": {
+                                    "DOI": "10.9999/xxxxi22",
+                                    "Proprietary": "P1:I22",
+                                    "URI": "https://doi.org/10.9999/xxxxi22"
+                                },
+                                "Attribute_Performance": [
+                                    {
+                                        "Data_Type": "Sound",
+                                        "Performance": {
+                                            "Total_Item_Requests": {
+                                                "2022-01": 876,
+                                                "2022-02": 1143,
+                                                "2022-03": 1066
+                                            },
+                                            "Unique_Item_Requests": {
+                                                "2022-01": 657,
+                                                "2022-02": 857,
+                                                "2022-03": 800
                                             }
                                         }
                                     }

--- a/api-specification/COUNTER_API.json
+++ b/api-specification/COUNTER_API.json
@@ -17006,6 +17006,140 @@
                             "items": {
                                 "$ref": "#/components/schemas/Report"
                             }
+                        },
+                        "examples": {
+                            "Example 1": {
+                                "value": [
+                                    {
+                                        "Report_Name": "Platform Report",
+                                        "Report_ID": "PR",
+                                        "Release": "5.1",
+                                        "Report_Description": "A customizable report summarizing activity across a report provider’s platforms that allows the user to apply filters and select other configuration options.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Platform Usage",
+                                        "Report_ID": "PR_P1",
+                                        "Release": "5.1",
+                                        "Report_Description": "Platform-level usage summarized by Metric_Type.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Database Report",
+                                        "Report_ID": "DR",
+                                        "Release": "5.1",
+                                        "Report_Description": "A customizable report detailing activity by database that allows the user to apply filters and select other configuration options.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Database Search and Item Usage",
+                                        "Report_ID": "DR_D1",
+                                        "Release": "5.1",
+                                        "Report_Description": "Reports on key Searches, Investigations and Requests metrics needed to evaluate a database.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Database Access Denied",
+                                        "Report_ID": "DR_D2",
+                                        "Release": "5.1",
+                                        "Report_Description": "Reports on Access Denied activity for databases where users were denied access because simultaneous-use licenses were exceeded or their institution did not have a license for the database.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Title Report",
+                                        "Report_ID": "TR",
+                                        "Release": "5.1",
+                                        "Report_Description": "A customizable report detailing activity at the title level (journal, book, etc.) that allows the user to apply filters and select other configuration options.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Book Requests (Controlled)",
+                                        "Report_ID": "TR_B1",
+                                        "Release": "5.1",
+                                        "Report_Description": "Reports on full-text activity for books, excluding Open and Free_To_Read content, as Total_Item_Requests and Unique_Title_Requests.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Book Access Denied",
+                                        "Report_ID": "TR_B2",
+                                        "Release": "5.1",
+                                        "Report_Description": "Reports on Access Denied activity for books where users were denied access because simultaneous-use licenses were exceeded or their institution did not have a license for the book.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Book Usage by Access Type",
+                                        "Report_ID": "TR_B3",
+                                        "Release": "5.1",
+                                        "Report_Description": "Reports on book usage showing all applicable Metric_Types broken down by Access_Type.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Journal Requests (Controlled)",
+                                        "Report_ID": "TR_J1",
+                                        "Release": "5.1",
+                                        "Report_Description": "Reports on usage of journal content, excluding Open and Free_To_Read content, as Total_Item_Requests and Unique_Item_Requests.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Journal Access Denied",
+                                        "Report_ID": "TR_J2",
+                                        "Release": "5.1",
+                                        "Report_Description": "Reports on Access Denied activity for journal content where users were denied access because simultaneous-use licenses were exceeded or their institution did not have a license for the title.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Journal Usage by Access Type",
+                                        "Report_ID": "TR_J3",
+                                        "Release": "5.1",
+                                        "Report_Description": "Reports on usage of journal content for all Metric_Types broken down by Access_Type.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Journal Requests by YOP (Controlled)",
+                                        "Report_ID": "TR_J4",
+                                        "Release": "5.1",
+                                        "Report_Description": "Breaks down the usage of journal content, excluding Open and Free_To_Read content, by year of publication (YOP), providing counts for the Metric_Types Total_Item_Requests and Unique_Item_Requests.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Item Report",
+                                        "Report_ID": "IR",
+                                        "Release": "5.1",
+                                        "Report_Description": "A granular, customizable report showing activity at the level of the item (article, chapter, media object, etc.) that allows the user to apply filters and select other configuration options.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Journal Article Requests",
+                                        "Report_ID": "IR_A1",
+                                        "Release": "5.1",
+                                        "Report_Description": "Reports on journal article requests at the article level. This report is limited to content with a Data_Type of Article and Metric_Types of Total_Item_Requests and Unique_Item_Requests.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    },
+                                    {
+                                        "Report_Name": "Multimedia Item Requests",
+                                        "Report_ID": "IR_M1",
+                                        "Release": "5.1",
+                                        "Report_Description": "Reports on multimedia requests at the item level.",
+                                        "First_Month_Available": "2024-01",
+                                        "Last_Month_Available": "2024-11"
+                                    }
+                                ]
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Add examples from the sample reports to the COUNTER API Specification to replace broken or confusing examples automatically generated by Stoplight for

- Member Information and Report Information
- Base Report_Header
- Report_Filters and Report_Attributes for COUNTER Reports
- Attribute_Performance and Performance for COUNTER Reports and Standard Views
- Exception

There are no examples for Components (since we don't have sample reports with Components) and for shared models that don't appear as stand-alone objects.

Since this should fix most issues with the examples I haven't added a clarification about automatically generated examples.