### PR TITLE
Fix structure for Reports_Items with Components in the COUNTER API Specification

### DIFF
--- a/api-specification/COUNTER_API.json
+++ b/api-specification/COUNTER_API.json
@@ -14166,6 +14166,14 @@
                             },
                             "Performance": {
                                 "$ref": "#/components/schemas/IR_Performance"
+                            },
+                            "Components": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/IR_Component_Item"
+                                },
+                                "uniqueItems": true,
+                                "minItems": 1
                             }
                         },
                         "required": [
@@ -14402,6 +14410,12 @@
                         "$ref": "#/components/schemas/Counts"
                     },
                     "Total_Item_Requests": {
+                        "$ref": "#/components/schemas/Counts"
+                    },
+                    "Limit_Exceeded": {
+                        "$ref": "#/components/schemas/Counts"
+                    },
+                    "No_License": {
                         "$ref": "#/components/schemas/Counts"
                     }
                 },
@@ -15450,14 +15464,6 @@
                             },
                             "Article_Version": {
                                 "$ref": "#/components/schemas/Article_Version"
-                            },
-                            "Components": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/components/schemas/IR_Component_Item"
-                                },
-                                "uniqueItems": true,
-                                "minItems": 1
                             }
                         }
                     }


### PR DESCRIPTION
This pull request moves the Components property from the Report_Item to the Report_Item Attribute_Performance to fix the wrong structure and adds the Metric_Types missing from the Component Performance. With theses changes the component usage can be reported properly in JSON Item Reports.