### PR TITLE
Fix permitted Granularity values in the COUNTER API Specification

### DIFF
--- a/api-specification/COUNTER_API.json
+++ b/api-specification/COUNTER_API.json
@@ -15641,7 +15641,7 @@
                         "type": "string",
                         "enum": [
                             "Month",
-                            "Total"
+                            "Totals"
                         ]
                     }
                 },
@@ -17319,10 +17319,10 @@
                     "type": "string",
                     "enum": [
                         "Month",
-                        "Total"
+                        "Totals"
                     ]
                 },
-                "description": "Optional Report_Attribute. Include this parameter to retrieve usage with a granularity of Month (default if omitted) or Total (usage not broken down by months)."
+                "description": "Optional Report_Attribute. Include this parameter to retrieve usage with a granularity of Month (default if omitted) or Totals (usage not broken down by months)."
             },
             "database": {
                 "name": "database",


### PR DESCRIPTION
This pull request aligns the COUNTER API Specification with the Code of Practice which specifies that the permitted Granularity values are Month and Totals (plural instead of singular).