### PR TITLE
Add missing keywords from RFC 2119 to Section Conventions

### DIFF
--- a/source/00-conventions.rst
+++ b/source/00-conventions.rst
@@ -14,14 +14,15 @@
 
 This Code of Practice is implemented using the following convention:
 
-The keywords MUST (or REQUIRED), MUST NOT, SHOULD (or RECOMMENDED), SHOULD NOT (or NOT RECOMMENDED), and OPTIONAL in this document are to be interpreted as described in `RFC 2119 <https://www.ietf.org/rfc/rfc2119.txt>`_.
+The keywords MUST, REQUIRED, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD (or RECOMMENDED), SHOULD NOT (or NOT RECOMMENDED), MAY, and OPTIONAL in this document are to be interpreted as described in `RFC 2119 <https://www.ietf.org/rfc/rfc2119.txt>`_.
 
 Note that the force of these words is modified by the requirement level of the document in which they are used.
 
-#. MUST (or REQUIRED) means that the definition is an absolute requirement of the specification.
-#. MUST NOT means that the definition is an absolute prohibition of the specification.
-#. SHOULD (or RECOMMENDED) means that there may be valid reasons in certain circumstances to ignore a particular item, but the full implications should be understood and carefully weighed before choosing a different course.
-#. SHOULD NOT (or NOT RECOMMENDED) means that there may be valid reasons in certain circumstances when the particular behaviour is acceptable or even useful, but the full implications should be understood and the case carefully weighed before implementing any behaviour described with this label.
+#. MUST, SHALL, or REQUIRED, means that the definition is an absolute requirement of the specification.
+#. MUST NOT, or SHALL NOT, means that the definition is an absolute prohibition of the specification.
+#. SHOULD, or RECOMMENDED, means that there may be valid reasons in certain circumstances to ignore a particular item, but the full implications should be understood and carefully weighed before choosing a different course.
+#. SHOULD NOT, or NOT RECOMMENDED, means that there may be valid reasons in certain circumstances when the particular behaviour is acceptable or even useful, but the full implications should be understood and the case carefully weighed before implementing any behaviour described with this label.
+#. MAY, or OPTIONAL, means than an item is truly optional.
 
 Report providers implementing the Code of Practice who feel they have a valid disagreement with a requirement of the code are requested to present their case in writing to the COUNTER Executive Director (code@countermetrics.org) and ask for clarification on interpretation of the code.
 

--- a/source/00-conventions.rst
+++ b/source/00-conventions.rst
@@ -14,7 +14,7 @@
 
 This Code of Practice is implemented using the following convention:
 
-The keywords MUST, REQUIRED, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD (or RECOMMENDED), SHOULD NOT (or NOT RECOMMENDED), MAY, and OPTIONAL in this document are to be interpreted as described in `RFC 2119 <https://www.ietf.org/rfc/rfc2119.txt>`_.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in `RFC 2119 <https://www.ietf.org/rfc/rfc2119.txt>`_.
 
 Note that the force of these words is modified by the requirement level of the document in which they are used.
 


### PR DESCRIPTION
Updated section on Conventions to more closely comply with https://www.ietf.org/rfc/rfc2119.txt. Added shall, shall not, and may to list and descriptions.