### PR TITLE
Fix the Status.Registry_Record description and mark the element as required

### DIFF
--- a/api-specification/COUNTER_API.json
+++ b/api-specification/COUNTER_API.json
@@ -1282,7 +1282,7 @@
                     "Registry_Record": {
                         "type": "string",
                         "pattern": "^(https://registry.countermetrics.org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
-                        "description": "The link to the platform’s COUNTER Registry record. Report providers who do not have a Registry record MUST omit this element."
+                        "description": "The link to the platform’s COUNTER Registry record. Report providers who do not have a Registry record MUST leave the value blank."
                     },
                     "Note": {
                         "type": "string",
@@ -1309,7 +1309,8 @@
                     }
                 },
                 "required": [
-                    "Service_Active"
+                    "Service_Active",
+                    "Registry_Record"
                 ],
                 "examples": [
                     {


### PR DESCRIPTION
This PR fixes #302. The description of the Status.Registry_Record is changed and the element marked as required, so that the specification of the element matches the Report_Header.Registry_Record specification.