### PR TITLE
Update license headers and footers

### DIFF
--- a/source/00-conventions.rst
+++ b/source/00-conventions.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/00-foreword.rst
+++ b/source/00-foreword.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/01-introduction/index.rst
+++ b/source/01-introduction/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/02-overview/index.rst
+++ b/source/02-overview/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/03-specifications/01-counter-reports-for-consumers.rst
+++ b/source/03-specifications/01-counter-reports-for-consumers.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/03-specifications/02-formats-for-counter-reports.rst
+++ b/source/03-specifications/02-formats-for-counter-reports.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/03-specifications/03-counter-report-common-attributes-and-elements.rst
+++ b/source/03-specifications/03-counter-report-common-attributes-and-elements.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/03-specifications/index.rst
+++ b/source/03-specifications/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/04-reports/01-platform-reports.rst
+++ b/source/04-reports/01-platform-reports.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/04-reports/02-database-reports.rst
+++ b/source/04-reports/02-database-reports.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/04-reports/03-title-reports.rst
+++ b/source/04-reports/03-title-reports.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/04-reports/04-item-reports.rst
+++ b/source/04-reports/04-item-reports.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/04-reports/index.rst
+++ b/source/04-reports/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/05-delivery/01-delivering-json-reports.rst
+++ b/source/05-delivery/01-delivering-json-reports.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/05-delivery/02-delivering-tabular-reports.rst
+++ b/source/05-delivery/02-delivering-tabular-reports.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/05-delivery/03-access-to-usage-for-consortia.rst
+++ b/source/05-delivery/03-access-to-usage-for-consortia.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/05-delivery/index.rst
+++ b/source/05-delivery/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/06-logging/01-log-file-analysis.rst
+++ b/source/06-logging/01-log-file-analysis.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/06-logging/02-page-tagging.rst
+++ b/source/06-logging/02-page-tagging.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/06-logging/03-syndicated-usage.rst
+++ b/source/06-logging/03-syndicated-usage.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/06-logging/index.rst
+++ b/source/06-logging/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/01-http-status-codes.rst
+++ b/source/07-processing/01-http-status-codes.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/02-double-click-filtering.rst
+++ b/source/07-processing/02-double-click-filtering.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/03-counting-unique-items.rst
+++ b/source/07-processing/03-counting-unique-items.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/04-counting-unique-titles.rst
+++ b/source/07-processing/04-counting-unique-titles.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/05-attributing-usage-when-item-appears-in-more-than-one-database.rst
+++ b/source/07-processing/05-attributing-usage-when-item-appears-in-more-than-one-database.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/06-searches.rst
+++ b/source/07-processing/06-searches.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/07-federated-searches.rst
+++ b/source/07-processing/07-federated-searches.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/08-internet-robots-and-crawlers.rst
+++ b/source/07-processing/08-internet-robots-and-crawlers.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/09-tools-and-features-that-enable-bulk-downloading.rst
+++ b/source/07-processing/09-tools-and-features-that-enable-bulk-downloading.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/10-text-and-data-mining.rst
+++ b/source/07-processing/10-text-and-data-mining.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/11-restating-data.rst
+++ b/source/07-processing/11-restating-data.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/12-usage-spikes.rst
+++ b/source/07-processing/12-usage-spikes.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/07-processing/index.rst
+++ b/source/07-processing/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/08-api/01-counter-api-paths-to-support.rst
+++ b/source/08-api/01-counter-api-paths-to-support.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/08-api/02-authentication-and-security-for-counter-api.rst
+++ b/source/08-api/02-authentication-and-security-for-counter-api.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/08-api/03-report-filters-and-report-attributes.rst
+++ b/source/08-api/03-report-filters-and-report-attributes.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/08-api/04-errors-and-exceptions.rst
+++ b/source/08-api/04-errors-and-exceptions.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/08-api/index.rst
+++ b/source/08-api/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/09-audit/01-the-audit-process.rst
+++ b/source/09-audit/01-the-audit-process.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/09-audit/02-categories-of-audit-result.rst
+++ b/source/09-audit/02-categories-of-audit-result.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/09-audit/03-timelines.rst
+++ b/source/09-audit/03-timelines.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/09-audit/04-counter-validator.rst
+++ b/source/09-audit/04-counter-validator.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/09-audit/05-inclusion-in-registry.rst
+++ b/source/09-audit/05-inclusion-in-registry.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/09-audit/index.rst
+++ b/source/09-audit/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/10-compliance/01-including-counter-in-license-agreements.rst
+++ b/source/10-compliance/01-including-counter-in-license-agreements.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/10-compliance/02-confidentiality-of-usage-data.rst
+++ b/source/10-compliance/02-confidentiality-of-usage-data.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/10-compliance/03-counter-reporting-for-consortia.rst
+++ b/source/10-compliance/03-counter-reporting-for-consortia.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/10-compliance/04-counter-for-repositories.rst
+++ b/source/10-compliance/04-counter-for-repositories.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/10-compliance/05-pathway-to-compliance.rst
+++ b/source/10-compliance/05-pathway-to-compliance.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/10-compliance/index.rst
+++ b/source/10-compliance/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/11-extending/01-platform-as-a-namespace.rst
+++ b/source/11-extending/01-platform-as-a-namespace.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/11-extending/02-creating-customized-counter-reports.rst
+++ b/source/11-extending/02-creating-customized-counter-reports.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/11-extending/03-creating-new-elements-columns-headings.rst
+++ b/source/11-extending/03-creating-new-elements-columns-headings.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/11-extending/04-creating-new-values-for-enumerated-elements-and-attributes.rst
+++ b/source/11-extending/04-creating-new-values-for-enumerated-elements-and-attributes.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/11-extending/05-reserved-values-available-for-extending-reports.rst
+++ b/source/11-extending/05-reserved-values-available-for-extending-reports.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/11-extending/06-restrictions-in-using-customized-elements-and-values.rst
+++ b/source/11-extending/06-restrictions-in-using-customized-elements-and-values.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/11-extending/index.rst
+++ b/source/11-extending/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/12-maintenance/01-instructions-for-submittal-of-proposed-change.rst
+++ b/source/12-maintenance/01-instructions-for-submittal-of-proposed-change.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/12-maintenance/02-review-of-change-requests.rst
+++ b/source/12-maintenance/02-review-of-change-requests.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/12-maintenance/03-resolution-of-proposed-changes.rst
+++ b/source/12-maintenance/03-resolution-of-proposed-changes.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/12-maintenance/04-implementation-schedule.rst
+++ b/source/12-maintenance/04-implementation-schedule.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/12-maintenance/index.rst
+++ b/source/12-maintenance/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/13-transitioning/01-transitioning-to-a-new-reporting-service.rst
+++ b/source/13-transitioning/01-transitioning-to-a-new-reporting-service.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/13-transitioning/02-transitioning-to-a-new-code-of-practice.rst
+++ b/source/13-transitioning/02-transitioning-to-a-new-code-of-practice.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/13-transitioning/03-transitioning-from-counter-r5-to-r51.rst
+++ b/source/13-transitioning/03-transitioning-from-counter-r5-to-r51.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/13-transitioning/index.rst
+++ b/source/13-transitioning/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/14-history/index.rst
+++ b/source/14-history/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/a-glossary-of-terms.rst
+++ b/source/appendices/a-glossary-of-terms.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/b-changes-from-r5.rst
+++ b/source/appendices/b-changes-from-r5.rst
@@ -1,5 +1,5 @@
 
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/c-declaration-of-counter-compliance.rst
+++ b/source/appendices/c-declaration-of-counter-compliance.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/d-handling-errors-and-exceptions.rst
+++ b/source/appendices/d-handling-errors-and-exceptions.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/e-audit-requirements-and-tests/01-audit-requirements.rst
+++ b/source/appendices/e-audit-requirements-and-tests/01-audit-requirements.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/e-audit-requirements-and-tests/02-general-tests.rst
+++ b/source/appendices/e-audit-requirements-and-tests/02-general-tests.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/e-audit-requirements-and-tests/03-denial-tests.rst
+++ b/source/appendices/e-audit-requirements-and-tests/03-denial-tests.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/e-audit-requirements-and-tests/04-search-tests.rst
+++ b/source/appendices/e-audit-requirements-and-tests/04-search-tests.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/e-audit-requirements-and-tests/05-book-usage-tests.rst
+++ b/source/appendices/e-audit-requirements-and-tests/05-book-usage-tests.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/e-audit-requirements-and-tests/06-other-usage-tests.rst
+++ b/source/appendices/e-audit-requirements-and-tests/06-other-usage-tests.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/e-audit-requirements-and-tests/index.rst
+++ b/source/appendices/e-audit-requirements-and-tests/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/f-list-of-federated-search-products.rst
+++ b/source/appendices/f-list-of-federated-search-products.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/g-sample-counter-reports-and-standard-views.rst
+++ b/source/appendices/g-sample-counter-reports-and-standard-views.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/appendices/index.rst
+++ b/source/appendices/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -22,7 +22,7 @@ from datetime import datetime
 # -- Project information -----------------------------------------------------
 
 project = 'COUNTER Code of Practice Release 5'
-copyright = '2017-%d, COUNTER' % datetime.now().year
+copyright = '2017-%d by COUNTER Metrics. The COUNTER Code of Practice is licensed under CC BY 4.0.' % datetime.now().year
 author = 'COUNTER'
 
 # The short X.Y version
@@ -219,7 +219,8 @@ latex_elements = {
             \centering
             \fbox{%
                 \begin{minipage}{0.80\textwidth}
-                    The Code of Practice is available from the \href{https://www.countermetrics.org/}{COUNTER website} as an interactive code. This online version is the version of record for Release 5 of the Code of Practice.
+                    The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics is licensed under \href{https://creativecommons.org/licenses/by/4.0/}{CC BY 4.0}.
+                    The Code of Practice is available from the \href{https://www.countermetrics.org/}{COUNTER website} as an interactive code. This online version is the version of record for Release 5.1.0.1.
                 \end{minipage}
             }
             \vspace{50pt}

--- a/source/conf.py
+++ b/source/conf.py
@@ -22,7 +22,7 @@ from datetime import datetime
 # -- Project information -----------------------------------------------------
 
 project = 'COUNTER Code of Practice Release 5'
-copyright = '2017-%d by COUNTER Metrics. The COUNTER Code of Practice is licensed under CC BY 4.0.' % datetime.now().year
+copyright = '2017-%d by COUNTER Metrics. The COUNTER Code of Practice is licensed under CC BY 4.0' % datetime.now().year
 author = 'COUNTER'
 
 # The short X.Y version

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,4 +1,4 @@
-.. The COUNTER Code of Practice © 2017-2024 by COUNTER Metrics
+.. The COUNTER Code of Practice © 2017-2026 by COUNTER Metrics
    is licensed under CC BY 4.0. To view a copy of this license,
    visit https://creativecommons.org/licenses/by/4.0/
 


### PR DESCRIPTION
I've updated the header in all reStructuredText files.

The footer in the HTML version is created by the copyright option. The resulting text always starts with Copyright, so I had to adapt the text. A hyperlink doesn't work here, therefore I've omitted the link.

The copyright and license information was missing from the PDF version. I've updated the box on the bottom of the title page to include the information.