### PR TITLE
Update configuration for building the CoP documents

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-26.04
   tools:
-    python: "3.11"
+    python: "3.14"
 
 # Build documentation in the source directory with Sphinx
 sphinx:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: sphinx
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 venv:
-	python3.11 -m venv venv
+	python3.14 -m venv venv
 	venv/bin/pip -q install --upgrade pip
 	venv/bin/pip -q install -r requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Sphinx==7.2.*
+Sphinx==8.2.*
 sphinx-rtd-theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -77,10 +77,10 @@ rst_prolog = '''
        <br />
     .. |lb| raw:: latex
 
-       {\linebreak}
+       {\\linebreak}
     .. |clearpage| raw:: latex
 
-       {\clearpage}
+       {\\clearpage}
     .. |blscape| raw:: latex
 
        \\begin{landscape}
@@ -109,8 +109,7 @@ except ImportError:
 #
 html_theme_options = {
     'navigation_depth': 3,
-    'logo_only': True,
-    'display_version': False
+    'logo_only': True
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
The PR updates Ubuntu and Python to the latest stable versions. Sphinx 9.0 causes layout problems with some elements in the PDF version, and fixing them would require significant changes, therefore Sphinx is upgraded to version 8.2.