### PR TITLE
Fix title definition of `Article_Version` (#382)

### DIFF
--- a/api-specification/COUNTER_API.json
+++ b/api-specification/COUNTER_API.json
@@ -15926,7 +15926,7 @@
                 ]
             },
             "Article_Version": {
-                "title": "Article_Versoin",
+                "title": "Article_Version",
                 "type": "string",
                 "x-stoplight": {
                     "id": "v9lspau3grn3r"


### PR DESCRIPTION
Changed the `Article_Version` title to not have any typo

Closes #382
