### PR TITLE
Add common extension Platforms to Section 11.7 and the COUNTER API Specification

### DIFF
--- a/api-specification/COUNTER_API.json
+++ b/api-specification/COUNTER_API.json
@@ -27,6 +27,10 @@
             "description": "Path and models specific for Member List"
         },
         {
+            "name": "Platform List",
+            "description": "Path and models specific for Platform List"
+        },
+        {
             "name": "Report List",
             "description": "Path and models specific for Report List"
         },
@@ -172,6 +176,51 @@
                 "description": "Returns the institutions associated with the customer ID in the request and their customer IDs and requestor IDs (if required for API calls and differing from the requestor ID in the request).\n\nThe associated institutions can be consortium members, or sites for multi-site customers. If the customer in the request is neither a consortium nor multi-site, the list only includes the details for the customer itself.\n\nThis path is a good choice for testing COUNTER API credentials.",
                 "x-stoplight": {
                     "id": "cpeuj2etekukw"
+                }
+            },
+            "parameters": []
+        },
+        "/r51/platforms": {
+            "get": {
+                "summary": "Platform List",
+                "tags": [
+                    "Platform List"
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/200_Platforms"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/400_Exception_1030"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/401_Exception"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/403_Exception"
+                    },
+                    "429": {
+                        "$ref": "#/components/responses/429_Exception"
+                    },
+                    "503": {
+                        "$ref": "#/components/responses/503_Exception"
+                    }
+                },
+                "operationId": "get-r51-platforms",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/customer_id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/requestor_id"
+                    },
+                    {
+                        "$ref": "#/components/parameters/api_key"
+                    }
+                ],
+                "description": "Returns the list of platforms supported by the COUNTER API server for the credentials included in the request. The response SHOULD be customer specific if possible.\n\nThis API path is a common extension (see Section 11.7 of the Code of Practice for details). Support for common extensions is OPTIONAL, i.e. report providers can decide whether to support this API path or not.",
+                "x-stoplight": {
+                    "id": "f3klmp9xqr2wd"
                 }
             },
             "parameters": []
@@ -1390,6 +1439,53 @@
                 "x-tags": [
                     "Member List"
                 ]
+            },
+            "Platform": {
+                "type": "object",
+                "title": "Platform Information",
+                "description": "Information about a platform supported by the COUNTER API server.",
+                "x-stoplight": {
+                    "id": "tz8njvy4bcqh1"
+                },
+                "examples": [
+                    {
+                        "Platform_Parameter": "12",
+                        "Platform_Name": "EBSCOhost"
+                    },
+                    {
+                        "Platform_Parameter": "23",
+                        "Platform_Name": "ProQuest",
+                        "Platform_Description": "Reports for the www.proquest.com platform"
+                    },
+                    {
+                        "Platform_Parameter": "41",
+                        "Platform_Name": "ScienceDirect"
+                    }
+                ],
+                "x-tags": [
+                    "Platform List"
+                ],
+                "required": [
+                    "Platform_Parameter",
+                    "Platform_Name"
+                ],
+                "properties": {
+                    "Platform_Parameter": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Value to be used for the platform parameter on other API paths."
+                    },
+                    "Platform_Name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Name of the platform."
+                    },
+                    "Platform_Description": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Additional information about the platform."
+                    }
+                }
             },
             "Report": {
                 "type": "object",
@@ -17210,6 +17306,40 @@
                             "uniqueItems": true,
                             "items": {
                                 "$ref": "#/components/schemas/Member"
+                            }
+                        }
+                    }
+                }
+            },
+            "200_Platforms": {
+                "description": "Platform List response",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "array",
+                            "minItems": 1,
+                            "uniqueItems": true,
+                            "items": {
+                                "$ref": "#/components/schemas/Platform"
+                            }
+                        },
+                        "examples": {
+                            "Example 1": {
+                                "value": [
+                                    {
+                                        "Platform_Parameter": "12",
+                                        "Platform_Name": "EBSCOhost"
+                                    },
+                                    {
+                                        "Platform_Parameter": "23",
+                                        "Platform_Name": "ProQuest",
+                                        "Platform_Description": "Reports for the www.proquest.com platform"
+                                    },
+                                    {
+                                        "Platform_Parameter": "41",
+                                        "Platform_Name": "ScienceDirect"
+                                    }
+                                ]
                             }
                         }
                     }

--- a/api-specification/COUNTER_API.json
+++ b/api-specification/COUNTER_API.json
@@ -1469,6 +1469,7 @@
                     "Platform_Parameter",
                     "Platform_Name"
                 ],
+                "additionalProperties": false,
                 "properties": {
                     "Platform_Parameter": {
                         "type": "string",

--- a/source/11-extending/07-api-extensions-for-the-counter-api.rst
+++ b/source/11-extending/07-api-extensions-for-the-counter-api.rst
@@ -9,16 +9,18 @@ Extensions for the COUNTER API
 
 In addition to the extensions that can be included in COUNTER Reports (see :numref:`reserved-elements`), COUNTER recognizes that report providers may want to extend the COUNTER API to provide additional information to report consumers. This section describes OPTIONAL API extensions that can be included in COUNTER API responses.
 
+
 Requesting API Extensions
 """""""""""""""""""""""""
 
-API extensions are requested using an ``include_{element name in lower case}`` parameter with permissible values ``False`` (default) and ``True``. This follows the same pattern as the ``include_parent_details`` and ``include_component_details`` report attributes (see :numref:`filters-attributes`).
+API extensions can either be additional API paths or extensions to existing paths. In the latter case they are requested using an ``include_{element name in lower case}`` parameter with permissible values ``False`` (default) and ``True``. This follows the same pattern as the ``include_parent_details`` and ``include_component_details`` report attributes (see :numref:`filters-attributes`).
 
-Support for API extensions is OPTIONAL. If a report provider does not support an extension, the response SHOULD be the same as when the parameter is omitted or set to ``False``. Report providers that do not support an extension are not expected to implement any special way of signaling that the extension is not supported.
+Support for API extensions is OPTIONAL. If a report provider does not support an extension to an existing path, the response SHOULD be the same as when the parameter is omitted or set to ``False``. Report providers that do not support an extension are not expected to implement any special way of signaling that the extension is not supported.
 
 When an extension is supported, the information SHOULD be customer specific where possible. For example, the date on which data for a month last changed may depend on the customer ID and other credentials used in the request.
 
 When information for an extension is not available, the corresponding element MUST be omitted rather than included with an empty or placeholder value.
+
 
 Month_Details Extension
 """""""""""""""""""""""
@@ -59,3 +61,52 @@ An example of a report entry in the response for ``/r51/reports`` with the Month
 The ``Month_Details`` element MAY be included for some reports in the response and omitted for others. Report consumers can compare the ``Last_Change_Date`` value for a month with the date and time when they last harvested usage data for that report and month to determine whether reharvesting is needed.
 
 No particular order is required for the month keys in ``Month_Details`` but descending chronological order is RECOMMENDED. Each month key MUST be within the range from ``First_Month_Available`` to ``Last_Month_Available`` inclusive for that report.
+
+
+Platforms Extension
+"""""""""""""""""""
+
+The Platforms extension allows report providers to return the list of platforms supported by the COUNTER API server for the credentials included in the request. Support for the Platforms extension is OPTIONAL, i.e. report providers can decide whether to support the extension or not. If the Platforms extension is not supported, the COUNTER API server MUST respond with HTTP status code 404 (as required by :ref:`Appendix D <appendix-d>` for unsupported paths).
+
+.. only:: latex
+
+   .. tabularcolumns:: |>{\raggedright\arraybackslash}\Y{0.11}|>{\raggedright\arraybackslash}\Y{0.18}|>{\parskip=\tparskip}\Y{0.71}|
+
+.. list-table::
+   :class: longtable
+   :widths: 8 14 78
+   :header-rows: 1
+
+   * - HTTP Method
+     - Path
+     - Description
+
+   * - GET
+     - /r51/platforms
+     - Returns the list of platforms supported by the COUNTER API server for the credentials included in the request. The response SHOULD be customer specific if possible. For each platform the response includes a ``Platform_Parameter`` value to be used for the ``platform`` parameter on other API paths,  a ``Platform_Name`` for identifying the platform, and an optional ``Platform_Description`` for providing additional information about the platform.
+
+       If the COUNTER API server requires the ``platform`` parameter for the standard API paths, the response includes the platforms that can be requested with the given credentials. If the COUNTER API server uses the ``platform`` parameter as a usual report filter, the response includes the values available for the Platform filter.
+
+       This path MUST be protected by the methods described in :numref:`api-security`.
+
+The Platforms extension could not only be useful for report providers who want to make this information available, and for report consumers who want to harvest reports for specific platforms on which usage occured, but also for usage consolidation platforms that harvest COUNTER reports from multiple report provider platforms and offer a COUNTER API for access to the harvested reports. Here is an example of what a ``/r51/platforms`` response could look like for such a platform:
+
+.. code-block:: JSON
+
+   [
+     {
+       "Platform_Parameter": "12",
+       "Platform_Name": "EBSCOhost"
+     },
+     {
+       "Platform_Parameter": "23",
+       "Platform_Name": "ProQuest",
+       "Platform_Description": "Reports for the www.proquest.com platform"
+     },
+     {
+       "Platform_Parameter": "41",
+       "Platform_Name": "ScienceDirect"
+     }
+   ]
+
+For example ``platform=12`` would be used for requesting EBSCOhost reports from the platform.


### PR DESCRIPTION
This PR adds the common extension Platforms that allows report providers to return the list of platforms supported by the COUNTER API server for the credentials included in the request, based on the Code Team discussions.