### PR TITLE
Fix Standard View Report_Filters definitions in the COUNTER API Specification

### DIFF
--- a/api-specification/COUNTER_API.json
+++ b/api-specification/COUNTER_API.json
@@ -8790,14 +8790,17 @@
                             },
                             "Metric_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Searches_Platform",
-                                    "Total_Item_Requests",
-                                    "Unique_Item_Requests",
-                                    "Unique_Title_Requests"
-                                ],
+                                "minItems": 4,
+                                "maxItems": 4,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Searches_Platform",
+                                        "Total_Item_Requests",
+                                        "Unique_Item_Requests",
+                                        "Unique_Title_Requests"
+                                    ]
                                 }
                             }
                         },
@@ -8809,6 +8812,21 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "PR_P1 - Report_Filters",
+                "examples": [
+                    {
+                        "Metric_Type": [
+                            "Searches_Platform",
+                            "Total_Item_Requests",
+                            "Unique_Item_Requests",
+                            "Unique_Title_Requests"
+                        ],
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31",
+                        "Access_Method": [
+                            "Regular"
+                        ]
+                    }
+                ],
                 "x-tags": [
                     "PR_P1 - Platform Usage"
                 ],
@@ -10397,17 +10415,20 @@
                             },
                             "Metric_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Searches_Automated",
-                                    "Searches_Federated",
-                                    "Searches_Regular",
-                                    "Total_Item_Investigations",
-                                    "Total_Item_Requests",
-                                    "Unique_Item_Investigations",
-                                    "Unique_Item_Requests"
-                                ],
+                                "minItems": 7,
+                                "maxItems": 7,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Searches_Automated",
+                                        "Searches_Federated",
+                                        "Searches_Regular",
+                                        "Total_Item_Investigations",
+                                        "Total_Item_Requests",
+                                        "Unique_Item_Investigations",
+                                        "Unique_Item_Requests"
+                                    ]
                                 }
                             }
                         },
@@ -10419,6 +10440,24 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "DR_D1 - Report_Filters",
+                "examples": [
+                    {
+                        "Metric_Type": [
+                            "Searches_Automated",
+                            "Searches_Federated",
+                            "Searches_Regular",
+                            "Total_Item_Investigations",
+                            "Total_Item_Requests",
+                            "Unique_Item_Investigations",
+                            "Unique_Item_Requests"
+                        ],
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31",
+                        "Access_Method": [
+                            "Regular"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "9zfmg650jn92g"
                 },
@@ -10726,12 +10765,15 @@
                             },
                             "Metric_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Limit_Exceeded",
-                                    "No_License"
-                                ],
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Limit_Exceeded",
+                                        "No_License"
+                                    ]
                                 }
                             }
                         },
@@ -10743,6 +10785,19 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "DR_D2 - Report_Filters",
+                "examples": [
+                    {
+                        "Metric_Type": [
+                            "Limit_Exceeded",
+                            "No_License"
+                        ],
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31",
+                        "Access_Method": [
+                            "Regular"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "ehemckrahnild"
                 },
@@ -11509,22 +11564,28 @@
                             },
                             "Data_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Book",
-                                    "Reference_Work"
-                                ],
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Book",
+                                        "Reference_Work"
+                                    ]
                                 }
                             },
                             "Metric_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Total_Item_Requests",
-                                    "Unique_Title_Requests"
-                                ],
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Total_Item_Requests",
+                                        "Unique_Title_Requests"
+                                    ]
                                 }
                             }
                         },
@@ -11538,6 +11599,26 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "TR_B1 - Report_Filters",
+                "examples": [
+                    {
+                        "Metric_Type": [
+                            "Total_Item_Requests",
+                            "Unique_Title_Requests"
+                        ],
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31",
+                        "Data_Type": [
+                            "Book",
+                            "Reference_Work"
+                        ],
+                        "Access_Type": [
+                            "Controlled"
+                        ],
+                        "Access_Method": [
+                            "Regular"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "ht1u32e0qo3df"
                 },
@@ -11779,22 +11860,28 @@
                             },
                             "Data_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Book",
-                                    "Reference_Work"
-                                ],
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Book",
+                                        "Reference_Work"
+                                    ]
                                 }
                             },
                             "Metric_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Limit_Exceeded",
-                                    "No_License"
-                                ],
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Limit_Exceeded",
+                                        "No_License"
+                                    ]
                                 }
                             }
                         },
@@ -11807,6 +11894,23 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "TR_B2 - Report_Filters",
+                "examples": [
+                    {
+                        "Metric_Type": [
+                            "Limit_Exceeded",
+                            "No_License"
+                        ],
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31",
+                        "Data_Type": [
+                            "Book",
+                            "Reference_Work"
+                        ],
+                        "Access_Method": [
+                            "Regular"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "phn2zdtzdjf2m"
                 },
@@ -12052,26 +12156,32 @@
                             },
                             "Data_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Book",
-                                    "Reference_Work"
-                                ],
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Book",
+                                        "Reference_Work"
+                                    ]
                                 }
                             },
                             "Metric_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Total_Item_Investigations",
-                                    "Total_Item_Requests",
-                                    "Unique_Item_Investigations",
-                                    "Unique_Item_Requests",
-                                    "Unique_Title_Investigations",
-                                    "Unique_Title_Requests"
-                                ],
+                                "minItems": 6,
+                                "maxItems": 6,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Total_Item_Investigations",
+                                        "Total_Item_Requests",
+                                        "Unique_Item_Investigations",
+                                        "Unique_Item_Requests",
+                                        "Unique_Title_Investigations",
+                                        "Unique_Title_Requests"
+                                    ]
                                 }
                             }
                         },
@@ -12084,6 +12194,27 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "TR_B3 - Report_Filters",
+                "examples": [
+                    {
+                        "Metric_Type": [
+                            "Total_Item_Investigations",
+                            "Total_Item_Requests",
+                            "Unique_Item_Investigations",
+                            "Unique_Item_Requests",
+                            "Unique_Title_Investigations",
+                            "Unique_Title_Requests"
+                        ],
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31",
+                        "Data_Type": [
+                            "Book",
+                            "Reference_Work"
+                        ],
+                        "Access_Method": [
+                            "Regular"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "ke9h8rxb7r0bg"
                 },
@@ -12423,12 +12554,15 @@
                             },
                             "Metric_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Total_Item_Requests",
-                                    "Unique_Item_Requests"
-                                ],
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Total_Item_Requests",
+                                        "Unique_Item_Requests"
+                                    ]
                                 }
                             }
                         },
@@ -12442,6 +12576,25 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "TR_J1 - Report_Filters",
+                "examples": [
+                    {
+                        "Metric_Type": [
+                            "Total_Item_Requests",
+                            "Unique_Item_Requests"
+                        ],
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31",
+                        "Data_Type": [
+                            "Journal"
+                        ],
+                        "Access_Type": [
+                            "Controlled"
+                        ],
+                        "Access_Method": [
+                            "Regular"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "oc13fhmyf0nyb"
                 },
@@ -12674,12 +12827,15 @@
                             },
                             "Metric_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Limit_Exceeded",
-                                    "No_License"
-                                ],
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Limit_Exceeded",
+                                        "No_License"
+                                    ]
                                 }
                             }
                         },
@@ -12692,6 +12848,22 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "TR_J2 - Report_Filters",
+                "examples": [
+                    {
+                        "Metric_Type": [
+                            "Limit_Exceeded",
+                            "No_License"
+                        ],
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31",
+                        "Data_Type": [
+                            "Journal"
+                        ],
+                        "Access_Method": [
+                            "Regular"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "c53mkv2xtx80f"
                 },
@@ -12926,14 +13098,17 @@
                             },
                             "Metric_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Total_Item_Investigations",
-                                    "Total_Item_Requests",
-                                    "Unique_Item_Investigations",
-                                    "Unique_Item_Requests"
-                                ],
+                                "minItems": 4,
+                                "maxItems": 4,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Total_Item_Investigations",
+                                        "Total_Item_Requests",
+                                        "Unique_Item_Investigations",
+                                        "Unique_Item_Requests"
+                                    ]
                                 }
                             }
                         },
@@ -12946,6 +13121,24 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "TR_J3 - Report_Filters",
+                "examples": [
+                    {
+                        "Metric_Type": [
+                            "Total_Item_Investigations",
+                            "Total_Item_Requests",
+                            "Unique_Item_Investigations",
+                            "Unique_Item_Requests"
+                        ],
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31",
+                        "Data_Type": [
+                            "Journal"
+                        ],
+                        "Access_Method": [
+                            "Regular"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "eugdonlrs30ln"
                 },
@@ -13257,12 +13450,15 @@
                             },
                             "Metric_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Total_Item_Requests",
-                                    "Unique_Item_Requests"
-                                ],
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Total_Item_Requests",
+                                        "Unique_Item_Requests"
+                                    ]
                                 }
                             }
                         },
@@ -13276,6 +13472,25 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "TR_J4 - Report_Filters",
+                "examples": [
+                    {
+                        "Metric_Type": [
+                            "Total_Item_Requests",
+                            "Unique_Item_Requests"
+                        ],
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31",
+                        "Data_Type": [
+                            "Journal"
+                        ],
+                        "Access_Type": [
+                            "Controlled"
+                        ],
+                        "Access_Method": [
+                            "Regular"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "uydreg86r0oox"
                 },
@@ -14724,12 +14939,15 @@
                             },
                             "Metric_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Total_Item_Requests",
-                                    "Unique_Item_Requests"
-                                ],
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Total_Item_Requests",
+                                        "Unique_Item_Requests"
+                                    ]
                                 }
                             }
                         },
@@ -14742,6 +14960,22 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "IR_A1 - Report_Filters",
+                "examples": [
+                    {
+                        "Metric_Type": [
+                            "Total_Item_Requests",
+                            "Unique_Item_Requests"
+                        ],
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31",
+                        "Data_Type": [
+                            "Article"
+                        ],
+                        "Access_Method": [
+                            "Regular"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "f3wg2xgn28myp"
                 },
@@ -15166,25 +15400,31 @@
                             },
                             "Data_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Audiovisual",
-                                    "Image",
-                                    "Interactive_Resource",
-                                    "Multimedia",
-                                    "Sound"
-                                ],
+                                "minItems": 5,
+                                "maxItems": 5,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Audiovisual",
+                                        "Image",
+                                        "Interactive_Resource",
+                                        "Multimedia",
+                                        "Sound"
+                                    ]
                                 }
                             },
                             "Metric_Type": {
                                 "type": "array",
-                                "const": [
-                                    "Total_Item_Requests",
-                                    "Unique_Item_Requests"
-                                ],
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "uniqueItems": true,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "Total_Item_Requests",
+                                        "Unique_Item_Requests"
+                                    ]
                                 }
                             }
                         },
@@ -15197,6 +15437,26 @@
                 ],
                 "unevaluatedProperties": false,
                 "title": "IR_M1 - Report_Filters",
+                "examples": [
+                    {
+                        "Metric_Type": [
+                            "Total_Item_Requests",
+                            "Unique_Item_Requests"
+                        ],
+                        "Begin_Date": "2022-01-01",
+                        "End_Date": "2022-03-31",
+                        "Data_Type": [
+                            "Audiovisual",
+                            "Image",
+                            "Interactive_Resource",
+                            "Multimedia",
+                            "Sound"
+                        ],
+                        "Access_Method": [
+                            "Regular"
+                        ]
+                    }
+                ],
                 "x-stoplight": {
                     "id": "xlx7is0nyhscl"
                 },


### PR DESCRIPTION
This PR fixes the definitions for all Standard View Report_Filters with multiple values in the COUNTER API Specification. It replaces the const arrays which require the same order in the report with enums and min/max/uniqueItems which allow any order. Additionally, the PR adds examples for the Report_Filters because the examples automatically generated by Stoplight.io are wrong.