### PR TITLE
Fix permitted domains for Registry_Record in the COUNTER API Specification

### DIFF
--- a/api-specification/COUNTER_API.json
+++ b/api-specification/COUNTER_API.json
@@ -1333,7 +1333,7 @@
                     },
                     "Registry_Record": {
                         "type": "string",
-                        "pattern": "^(https://registry.(countermetrics|projectcounter).org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
+                        "pattern": "^(https://registry\\.(countermetrics|projectcounter)\\.org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
                         "description": "The link to the platform’s COUNTER Registry record. Report providers who do not have a Registry record MUST leave the value blank."
                     },
                     "Note": {
@@ -7628,7 +7628,7 @@
                     },
                     "Registry_Record": {
                         "type": "string",
-                        "pattern": "^(https://registry.(countermetrics|projectcounter).org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
+                        "pattern": "^(https://registry\\.(countermetrics|projectcounter)\\.org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
                         "description": "The link to the platform’s COUNTER Registry record. Report providers who do not have a Registry record MUST leave the value blank."
                     }
                 },

--- a/api-specification/COUNTER_API.json
+++ b/api-specification/COUNTER_API.json
@@ -1333,7 +1333,7 @@
                     },
                     "Registry_Record": {
                         "type": "string",
-                        "pattern": "^(https://registry.countermetrics.org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
+                        "pattern": "^(https://registry.(countermetrics|projectcounter).org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
                         "description": "The link to the platform’s COUNTER Registry record. Report providers who do not have a Registry record MUST leave the value blank."
                     },
                     "Note": {
@@ -7628,7 +7628,7 @@
                     },
                     "Registry_Record": {
                         "type": "string",
-                        "pattern": "^(https://registry.countermetrics.org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
+                        "pattern": "^(https://registry.(countermetrics|projectcounter).org/(platform|usage-data-host)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|)$",
                         "description": "The link to the platform’s COUNTER Registry record. Report providers who do not have a Registry record MUST leave the value blank."
                     }
                 },

--- a/source/03-specifications/02-formats-for-counter-reports.rst
+++ b/source/03-specifications/02-formats-for-counter-reports.rst
@@ -124,6 +124,8 @@ Table 3.f (below): COUNTER Report Header Elements
 
    * - Registry_Record
      - The link to the platform's COUNTER Registry record. Report providers who do not have a Registry record MUST leave the value blank. Where a COUNTER Report is downloaded that includes usage data for multiple platforms in the COUNTER Registry, the Registry link should be to the Usage Data Host.
+
+       Note that using the current COUNTER Registry hostname registry.countermetrics.org is recommended for Registry_Record, but using the old hostname registry.projectcounter.org is still permitted for backward compatibility.
      - https://registry.countermetrics.org/platform/b2b2736c-2cb9-48ec-91f4-870336acfb1c (platform)\ |br|\ |lb|
        https://registry.countermetrics.org/usage-data-host/72a35413-6fcd-44f2-8bce-0c7b2373e33f (usage data host) 
 


### PR DESCRIPTION
This PR resolves #391. The lower case "recommend" in the note for Table 3.f is intentional, since we cannot require report providers to use the new domain.